### PR TITLE
refactor: centralize Prisma client

### DIFF
--- a/src/repositories/cultures.repository.js
+++ b/src/repositories/cultures.repository.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require("@prisma/client");
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 exports.findAll = async () => {
     return await prisma.products.findMany({

--- a/src/repositories/products.repository.js
+++ b/src/repositories/products.repository.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require("@prisma/client");
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 exports.upsertProduct = async ({ name, category, unit }) => {
     return await prisma.products.upsert({
       where: { name },

--- a/src/repositories/regions.repository.js
+++ b/src/repositories/regions.repository.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require("@prisma/client");
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 exports.findAll = async () => {
     return await prisma.regions.findMany();

--- a/src/repositories/stats.repository.js
+++ b/src/repositories/stats.repository.js
@@ -1,6 +1,5 @@
 // src/repositories/stats.repository.js
-const { PrismaClient } = require("@prisma/client");
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 exports.upsertStat = async ({ regionId, productId, year, surface, rendement, production }) => {
   const existing = await prisma.agricultural_stats.findFirst({


### PR DESCRIPTION
## Summary
- reuse Prisma instance exported by `config/prisma.js` inside all repositories

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684886a2e22c832aa1a353bcd3349555