### PR TITLE
Add domain models and DTO mapping layers

### DIFF
--- a/src/controllers/cultures.controller.js
+++ b/src/controllers/cultures.controller.js
@@ -1,9 +1,16 @@
 const culturesService = require("../services/cultures.service");
+const CultureDto = require("../dtos/culture.dto");
+
+function modelToDto(model) {
+    return new CultureDto({ name: model.name });
+}
+
+exports.toDto = modelToDto;
 
 exports.getAllCultures = async (req, res) => {
     try {
         const cultures = await culturesService.getAllCultures();
-        res.json(cultures);
+        res.json(cultures.map(modelToDto));
     } catch (err) {
         res.status(500).json({ error: "Erreur lors de la récupération des cultures" });
     }

--- a/src/controllers/regions.controller.js
+++ b/src/controllers/regions.controller.js
@@ -1,9 +1,16 @@
 const regionsService = require("../services/regions.service");
+const RegionDto = require("../dtos/region.dto");
+
+function modelToDto(model) {
+    return new RegionDto({ id: model.id, code: model.code, name: model.name });
+}
+
+exports.toDto = modelToDto;
 
 exports.getAllRegions = async (req, res) => {
     try {
         const regions = await regionsService.getAllRegions();
-        res.json(regions);
+        res.json(regions.map(modelToDto));
     } catch (error) {
         res.status(500).json({ error: "Erreur lors de la récupération des régions" });
     }

--- a/src/controllers/stats.controller.js
+++ b/src/controllers/stats.controller.js
@@ -1,10 +1,26 @@
 const statsService = require("../services/stats.service");
+const StatDto = require("../dtos/stat.dto");
+
+function modelToDto(model) {
+    return new StatDto({
+        id: model.id,
+        year: model.year,
+        surfaceHa: model.surfaceHa,
+        yieldQxHa: model.yieldQxHa,
+        productionT: model.productionT,
+        granularity: model.granularity,
+        region: model.region,
+        product: model.product,
+    });
+}
+
+exports.toDto = modelToDto;
 
 exports.getStatsByRegion = async (req, res) => {
     const { culture, year } = req.params;
     try {
         const stats = await statsService.getStatsByRegion(culture, parseInt(year));
-        res.json(stats);
+        res.json(stats.map(modelToDto));
     } catch (err) {
         res.status(500).json({ error: "Erreur lors de la récupération des statistiques" });
     }

--- a/src/dtos/culture.dto.js
+++ b/src/dtos/culture.dto.js
@@ -1,0 +1,6 @@
+class CultureDto {
+  constructor({ name }) {
+    this.name = name;
+  }
+}
+module.exports = CultureDto;

--- a/src/dtos/region.dto.js
+++ b/src/dtos/region.dto.js
@@ -1,0 +1,8 @@
+class RegionDto {
+  constructor({ id, code, name }) {
+    this.id = id;
+    this.code = code;
+    this.name = name;
+  }
+}
+module.exports = RegionDto;

--- a/src/dtos/stat.dto.js
+++ b/src/dtos/stat.dto.js
@@ -1,0 +1,13 @@
+class AgriculturalStatDto {
+  constructor({ id, year, surfaceHa, yieldQxHa, productionT, granularity, region, product }) {
+    this.id = id;
+    this.year = year;
+    this.surfaceHa = surfaceHa;
+    this.yieldQxHa = yieldQxHa;
+    this.productionT = productionT;
+    this.granularity = granularity;
+    this.region = region;
+    this.product = product;
+  }
+}
+module.exports = AgriculturalStatDto;

--- a/src/models/culture.model.js
+++ b/src/models/culture.model.js
@@ -1,0 +1,7 @@
+class Culture {
+  constructor({ id, name }) {
+    this.id = id;
+    this.name = name;
+  }
+}
+module.exports = Culture;

--- a/src/models/region.model.js
+++ b/src/models/region.model.js
@@ -1,0 +1,8 @@
+class Region {
+  constructor({ id, code, name }) {
+    this.id = id;
+    this.code = code;
+    this.name = name;
+  }
+}
+module.exports = Region;

--- a/src/models/stat.model.js
+++ b/src/models/stat.model.js
@@ -1,0 +1,13 @@
+class Stat {
+  constructor({ id, year, surfaceHa, yieldQxHa, productionT, granularity, region, product }) {
+    this.id = id;
+    this.year = year;
+    this.surfaceHa = surfaceHa;
+    this.yieldQxHa = yieldQxHa;
+    this.productionT = productionT;
+    this.granularity = granularity;
+    this.region = region;
+    this.product = product;
+  }
+}
+module.exports = Stat;

--- a/src/repositories/stats.repository.js
+++ b/src/repositories/stats.repository.js
@@ -35,3 +35,22 @@ exports.upsertStat = async ({ regionId, productId, year, surface, rendement, pro
     });
   }
 };
+
+exports.findStatsByRegion = async (culture, year) => {
+  return await prisma.agricultural_stats.findMany({
+    where: {
+      year,
+      granularity: 'region',
+      product: {
+        name: culture
+      }
+    },
+    include: {
+      region: true,
+      product: { select: { id: true, name: true } }
+    },
+    orderBy: {
+      region: { code: 'asc' }
+    }
+  });
+};

--- a/src/services/cultures.service.js
+++ b/src/services/cultures.service.js
@@ -1,7 +1,16 @@
 const culturesRepository = require("../repositories/cultures.repository");
+const Culture = require("../models/culture.model");
+
+function entityToModel(entity) {
+    if (!entity) return null;
+    return new Culture({ id: entity.id, name: entity.name });
+}
+
+exports.toModel = entityToModel;
 
 exports.getAllCultures = async () => {
-    return await culturesRepository.findAll();
+    const entities = await culturesRepository.findAll();
+    return entities.map(entityToModel);
 };
 
 exports.getAvailableYears = async () => {

--- a/src/services/regions.service.js
+++ b/src/services/regions.service.js
@@ -1,5 +1,14 @@
 const regionsRepository = require("../repositories/regions.repository");
+const Region = require("../models/region.model");
+
+function entityToModel(entity) {
+    if (!entity) return null;
+    return new Region({ id: entity.id, code: entity.code, name: entity.name });
+}
+
+exports.toModel = entityToModel;
 
 exports.getAllRegions = async () => {
-    return await regionsRepository.findAll();
+    const entities = await regionsRepository.findAll();
+    return entities.map(entityToModel);
 };

--- a/src/services/stats.service.js
+++ b/src/services/stats.service.js
@@ -1,5 +1,31 @@
 const statsRepository = require("../repositories/stats.repository");
+const Stat = require("../models/stat.model");
+const Region = require("../models/region.model");
+const Culture = require("../models/culture.model");
+
+function entityToModel(entity) {
+    if (!entity) return null;
+    const region = entity.region
+        ? new Region({ id: entity.region.id, code: entity.region.code, name: entity.region.name })
+        : undefined;
+    const product = entity.product
+        ? new Culture({ id: entity.product.id, name: entity.product.name })
+        : undefined;
+    return new Stat({
+        id: entity.id,
+        year: entity.year,
+        surfaceHa: entity.surface_ha,
+        yieldQxHa: entity.yield_qx_ha,
+        productionT: entity.production_t,
+        granularity: entity.granularity,
+        region,
+        product,
+    });
+}
+
+exports.toModel = entityToModel;
 
 exports.getStatsByRegion = async (culture, year) => {
-    return await statsRepository.findStatsByRegion(culture, year);
+    const entities = await statsRepository.findStatsByRegion(culture, year);
+    return entities.map(entityToModel);
 };


### PR DESCRIPTION
## Summary
- introduce Region, Culture and Stat models
- add DTO classes for API responses
- implement repository->model conversions in services
- implement model->DTO conversions in controllers
- expose stats repository query for retrieving stats by region

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68488f2991b8832a869959cad22fb369