### PR TITLE
Add response DTOs and mapping helpers

### DIFF
--- a/src/controllers/apps.controller.js
+++ b/src/controllers/apps.controller.js
@@ -1,5 +1,10 @@
 const jwt = require('jsonwebtoken');
 const appsService = require('../services/apps.service');
+const {
+  tokenToLoginResponseDto,
+  appModelToRegisterResponseDto,
+  appModelToRegisterKeyResponseDto,
+} = require('../mapping/app.mapping');
 
 exports.loginApp = async (req, res) => {
   const { name, secret } = req.body;
@@ -12,7 +17,7 @@ exports.loginApp = async (req, res) => {
     expiresIn: '1h'
   });
 
-  res.json({ token });
+  res.json(tokenToLoginResponseDto(token));
 };
 
 exports.registerApp = async (req, res) => {
@@ -21,7 +26,7 @@ exports.registerApp = async (req, res) => {
 
   try {
     const app = await appsService.registerApp({ name, secret });
-    res.status(201).json({ id: app.id, name: app.name });
+    res.status(201).json(appModelToRegisterResponseDto(app));
   } catch (err) {
     console.error('Erreur lors de l\'enregistrement de l\'application:', err);
     res.status(500).json({ error: "Erreur lors de l'enregistrement de l'application" });
@@ -34,7 +39,7 @@ exports.registerAppApiKey = async (req, res) => {
 
   try {
     const result = await appsService.createAppWithApiKey(name);
-    res.status(201).json(result);
+    res.status(201).json(appModelToRegisterKeyResponseDto(result));
   } catch (err) {
     console.error('Erreur création app avec clé API:', err);
     res.status(500).json({ error: 'Erreur serveur' });

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,5 +1,6 @@
 const usersService = require('../services/users.service');
 const jwt = require('jsonwebtoken');
+const { tokenToLoginResponseDto, userModelToRegisterResponseDto } = require('../mapping/user.mapping');
 
 exports.login = async (req, res) => {
   const { email, password } = req.body;
@@ -8,7 +9,7 @@ exports.login = async (req, res) => {
     const user = await usersService.authenticate(email, password);
     if (!user) return res.status(401).json({ error: 'Identifiants invalides' });
     const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
-    res.json({ token });
+    res.json(tokenToLoginResponseDto(token));
   } catch (err) {
     res.status(500).json({ error: "Erreur lors de l'authentification" });
   }
@@ -19,7 +20,7 @@ exports.register = async (req, res) => {
   if (!email || !password) return res.status(400).json({ error: 'Email et mot de passe requis' });
   try {
     const user = await usersService.createUser({ email, password, firstName, lastName });
-    res.status(201).json({ id: user.id, email: user.email });
+    res.status(201).json(userModelToRegisterResponseDto(user));
   } catch (err) {
     res.status(500).json({ error: "Erreur lors de la création de l'utilisateur" });
   }

--- a/src/controllers/import.controller.js
+++ b/src/controllers/import.controller.js
@@ -1,9 +1,10 @@
 const importService = require("../services/import.service");
+const { messageToImportResultDto } = require('../mapping/import.mapping');
 
 exports.importStatsFromExcel = async (req, res) => {
   try {
     await importService.importFromExcelBuffer(req.file.buffer);
-    res.status(201).json({ message: "Données importées avec succès." });
+    res.status(201).json(messageToImportResultDto("Données importées avec succès."));
   } catch (error) {
     console.error("Erreur d'import:", error);
     res.status(500).json({ error: "Échec de l'importation des données." });

--- a/src/dtos/app-register-key-response.dto.js
+++ b/src/dtos/app-register-key-response.dto.js
@@ -1,0 +1,8 @@
+class AppRegisterKeyResponseDto {
+  constructor({ id, name, apiKey }) {
+    this.id = id;
+    this.name = name;
+    this.apiKey = apiKey;
+  }
+}
+module.exports = AppRegisterKeyResponseDto;

--- a/src/dtos/app-register-response.dto.js
+++ b/src/dtos/app-register-response.dto.js
@@ -1,0 +1,7 @@
+class AppRegisterResponseDto {
+  constructor({ id, name }) {
+    this.id = id;
+    this.name = name;
+  }
+}
+module.exports = AppRegisterResponseDto;

--- a/src/dtos/import-result.dto.js
+++ b/src/dtos/import-result.dto.js
@@ -1,0 +1,6 @@
+class ImportResultDto {
+  constructor({ message }) {
+    this.message = message;
+  }
+}
+module.exports = ImportResultDto;

--- a/src/dtos/login-response.dto.js
+++ b/src/dtos/login-response.dto.js
@@ -1,0 +1,6 @@
+class LoginResponseDto {
+  constructor({ token }) {
+    this.token = token;
+  }
+}
+module.exports = LoginResponseDto;

--- a/src/dtos/register-response.dto.js
+++ b/src/dtos/register-response.dto.js
@@ -1,0 +1,7 @@
+class RegisterResponseDto {
+  constructor({ id, email }) {
+    this.id = id;
+    this.email = email;
+  }
+}
+module.exports = RegisterResponseDto;

--- a/src/mapping/app.mapping.js
+++ b/src/mapping/app.mapping.js
@@ -1,0 +1,24 @@
+const AppRegisterResponseDto = require('../dtos/app-register-response.dto');
+const AppRegisterKeyResponseDto = require('../dtos/app-register-key-response.dto');
+const LoginResponseDto = require('../dtos/login-response.dto');
+
+function appModelToRegisterResponseDto(app) {
+  if (!app) return null;
+  return new AppRegisterResponseDto({ id: app.id, name: app.name });
+}
+
+function appModelToRegisterKeyResponseDto(app) {
+  if (!app) return null;
+  return new AppRegisterKeyResponseDto({ id: app.id, name: app.name, apiKey: app.apiKey });
+}
+
+function tokenToLoginResponseDto(token) {
+  if (!token) return null;
+  return new LoginResponseDto({ token });
+}
+
+module.exports = {
+  appModelToRegisterResponseDto,
+  appModelToRegisterKeyResponseDto,
+  tokenToLoginResponseDto,
+};

--- a/src/mapping/import.mapping.js
+++ b/src/mapping/import.mapping.js
@@ -1,0 +1,10 @@
+const ImportResultDto = require('../dtos/import-result.dto');
+
+function messageToImportResultDto(message) {
+  if (!message) return null;
+  return new ImportResultDto({ message });
+}
+
+module.exports = {
+  messageToImportResultDto,
+};

--- a/src/mapping/user.mapping.js
+++ b/src/mapping/user.mapping.js
@@ -1,4 +1,6 @@
 const User = require('../models/user.model');
+const LoginResponseDto = require('../dtos/login-response.dto');
+const RegisterResponseDto = require('../dtos/register-response.dto');
 
 function entityToModel(entity) {
   if (!entity) return null;
@@ -11,7 +13,19 @@ function entityToModel(entity) {
   });
 }
 
+function tokenToLoginResponseDto(token) {
+  if (!token) return null;
+  return new LoginResponseDto({ token });
+}
+
+function userModelToRegisterResponseDto(model) {
+  if (!model) return null;
+  return new RegisterResponseDto({ id: model.id, email: model.email });
+}
+
 module.exports = {
   entityToModel,
+  tokenToLoginResponseDto,
+  userModelToRegisterResponseDto,
 };
 


### PR DESCRIPTION
## Summary
- add DTOs for login, register, app registration and import result
- map models to these DTOs
- return DTOs from auth, app and import controllers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c76d1b7d4832aa3e3aafb94c4eb46