### PR TITLE
Remove unused toModel exports

### DIFF
--- a/src/services/cultures.service.js
+++ b/src/services/cultures.service.js
@@ -6,7 +6,6 @@ function entityToModel(entity) {
     return new Culture({ id: entity.id, name: entity.name, code: entity.code });
 }
 
-exports.toModel = entityToModel;
 
 exports.getAllCultures = async () => {
     const entities = await culturesRepository.findAll();

--- a/src/services/regions.service.js
+++ b/src/services/regions.service.js
@@ -6,7 +6,6 @@ function entityToModel(entity) {
     return new Region({ id: entity.id, code: entity.code, name: entity.name });
 }
 
-exports.toModel = entityToModel;
 
 exports.getAllRegions = async () => {
     const entities = await regionsRepository.findAll();


### PR DESCRIPTION
## Summary
- drop unused `toModel` functions from culture and region services

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685b09be0f98832abc958d6fbe1b12c3