### PR TITLE
Use shared Prisma client

### DIFF
--- a/src/config/prisma.js
+++ b/src/config/prisma.js
@@ -1,3 +1,14 @@
 const { PrismaClient } = require('@prisma/client');
-const prisma = new PrismaClient();
+
+let prisma;
+
+if (process.env.NODE_ENV === 'production') {
+  prisma = new PrismaClient();
+} else {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient();
+  }
+  prisma = global.prisma;
+}
+
 module.exports = prisma;

--- a/src/repositories/apps.repository.js
+++ b/src/repositories/apps.repository.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require('@prisma/client');
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 exports.findByName = async (name) => {
   return await prisma.api_app.findUnique({ where: { name } });

--- a/src/repositories/geo.repository.js
+++ b/src/repositories/geo.repository.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require('@prisma/client');
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 exports.getStatsByRegion = async ({ year, productId }) => {
   const rows = await prisma.agricultural_stats.findMany({

--- a/src/repositories/stats.repository.js
+++ b/src/repositories/stats.repository.js
@@ -1,5 +1,4 @@
-const { PrismaClient } = require("@prisma/client");
-const prisma = new PrismaClient();
+const prisma = require('../config/prisma');
 
 exports.getFilteredStats = async ({ year, regionId, productId, granularity, page = 1, limit = 50 }) => {
   const where = {


### PR DESCRIPTION
## Summary
- centralize PrismaClient instance in `src/config/prisma.js`
- import shared client in `apps.repository.js`, `stats.repository.js` and `geo.repository.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c76d8fef8832a848b01b62d225be2