### PR TITLE
Add entity classes and return them from repositories

### DIFF
--- a/src/entities/product-summary.entity.js
+++ b/src/entities/product-summary.entity.js
@@ -1,0 +1,12 @@
+class ProductSummaryEntity {
+  constructor({ productId, name, totalSurface, avgYield, totalProduction, minYear, maxYear }) {
+    this.productId = productId;
+    this.name = name;
+    this.totalSurface = totalSurface;
+    this.avgYield = avgYield;
+    this.totalProduction = totalProduction;
+    this.minYear = minYear;
+    this.maxYear = maxYear;
+  }
+}
+module.exports = ProductSummaryEntity;

--- a/src/entities/product.entity.js
+++ b/src/entities/product.entity.js
@@ -1,0 +1,10 @@
+class ProductEntity {
+  constructor({ id, name, category, unit, code }) {
+    this.id = id;
+    this.name = name;
+    this.category = category;
+    this.unit = unit;
+    this.code = code;
+  }
+}
+module.exports = ProductEntity;

--- a/src/entities/region.entity.js
+++ b/src/entities/region.entity.js
@@ -1,0 +1,8 @@
+class RegionEntity {
+  constructor({ id, code, name }) {
+    this.id = id;
+    this.code = code;
+    this.name = name;
+  }
+}
+module.exports = RegionEntity;

--- a/src/entities/stat.entity.js
+++ b/src/entities/stat.entity.js
@@ -1,0 +1,30 @@
+class StatEntity {
+  constructor({
+    id,
+    year,
+    region_id,
+    department_id,
+    product_id,
+    surface_ha,
+    yield_qx_ha,
+    production_t,
+    granularity,
+    regions,
+    departments,
+    products,
+  }) {
+    this.id = id;
+    this.year = year;
+    this.region_id = region_id;
+    this.department_id = department_id;
+    this.product_id = product_id;
+    this.surface_ha = surface_ha;
+    this.yield_qx_ha = yield_qx_ha;
+    this.production_t = production_t;
+    this.granularity = granularity;
+    this.regions = regions;
+    this.departments = departments;
+    this.products = products;
+  }
+}
+module.exports = StatEntity;

--- a/src/entities/user.entity.js
+++ b/src/entities/user.entity.js
@@ -1,0 +1,12 @@
+class UserEntity {
+  constructor({ id, email, password_hash, first_name, last_name, role, created_at }) {
+    this.id = id;
+    this.email = email;
+    this.password_hash = password_hash;
+    this.first_name = first_name;
+    this.last_name = last_name;
+    this.role = role;
+    this.created_at = created_at;
+  }
+}
+module.exports = UserEntity;

--- a/src/mapping/culture.mapping.js
+++ b/src/mapping/culture.mapping.js
@@ -1,5 +1,6 @@
 const Culture = require('../models/culture.model');
 const CultureDto = require('../dtos/culture.dto');
+const ProductEntity = require('../entities/product.entity');
 
 function entityToModel(entity) {
   if (!entity) return null;

--- a/src/mapping/region.mapping.js
+++ b/src/mapping/region.mapping.js
@@ -1,5 +1,6 @@
 const Region = require('../models/region.model');
 const RegionDto = require('../dtos/region.dto');
+const RegionEntity = require('../entities/region.entity');
 
 function entityToModel(entity) {
   if (!entity) return null;

--- a/src/mapping/stat.mapping.js
+++ b/src/mapping/stat.mapping.js
@@ -4,6 +4,8 @@ const Region = require('../models/region.model');
 const Culture = require('../models/culture.model');
 const StatDto = require('../dtos/stat.dto');
 const ProductSummaryDto = require('../dtos/product-summary.dto');
+const StatEntity = require('../entities/stat.entity');
+const ProductSummaryEntity = require('../entities/product-summary.entity');
 
 function statEntityToModel(entity) {
   if (!entity) return null;

--- a/src/mapping/user.mapping.js
+++ b/src/mapping/user.mapping.js
@@ -1,4 +1,5 @@
 const User = require('../models/user.model');
+const UserEntity = require('../entities/user.entity');
 
 function entityToModel(entity) {
   if (!entity) return null;

--- a/src/repositories/cultures.repository.js
+++ b/src/repositories/cultures.repository.js
@@ -1,9 +1,9 @@
 const prisma = require('../config/prisma');
+const ProductEntity = require('../entities/product.entity');
 
 exports.findAll = async () => {
-    return await prisma.products.findMany({
-        select: { name: true, id: true, code: true }
-    });
+  const rows = await prisma.products.findMany();
+  return rows.map((row) => new ProductEntity(row));
 };
 
 exports.findYears = async () => {

--- a/src/repositories/products.repository.js
+++ b/src/repositories/products.repository.js
@@ -1,8 +1,10 @@
 const prisma = require('../config/prisma');
+const ProductEntity = require('../entities/product.entity');
 exports.upsertProduct = async ({ name, category, unit, code }) => {
-    return await prisma.products.upsert({
-      where: { name },
-      update: {},
-      create: { name, category, unit, code }
-    });
-  };
+  const row = await prisma.products.upsert({
+    where: { name },
+    update: {},
+    create: { name, category, unit, code },
+  });
+  return new ProductEntity(row);
+};

--- a/src/repositories/regions.repository.js
+++ b/src/repositories/regions.repository.js
@@ -1,13 +1,16 @@
 const prisma = require('../config/prisma');
+const RegionEntity = require('../entities/region.entity');
 
 exports.findAll = async () => {
-    return await prisma.regions.findMany();
+  const rows = await prisma.regions.findMany();
+  return rows.map((row) => new RegionEntity(row));
 };
 
 exports.upsertRegionByName = async (name, code) => {
-    return await prisma.regions.upsert({
-      where: { code },
-      update: {},
-      create: { code, name }
-    });
-  };
+  const row = await prisma.regions.upsert({
+    where: { code },
+    update: {},
+    create: { code, name },
+  });
+  return new RegionEntity(row);
+};

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -1,13 +1,17 @@
 const prisma = require('../config/prisma');
+const UserEntity = require('../entities/user.entity');
 
 exports.findByEmail = async (email) => {
-  return await prisma.users.findUnique({ where: { email } });
+  const row = await prisma.users.findUnique({ where: { email } });
+  return row ? new UserEntity(row) : null;
 };
 
 exports.createUser = async ({ email, passwordHash, firstName, lastName, role }) => {
-  return await prisma.users.create({ data: { email, password_hash: passwordHash, first_name: firstName, last_name: lastName, role } });
+  const row = await prisma.users.create({ data: { email, password_hash: passwordHash, first_name: firstName, last_name: lastName, role } });
+  return new UserEntity(row);
 };
 
 exports.findById = async (id) => {
-  return await prisma.users.findUnique({ where: { id } });
+  const row = await prisma.users.findUnique({ where: { id } });
+  return row ? new UserEntity(row) : null;
 };


### PR DESCRIPTION
## Summary
- define entity classes mirroring DB tables
- return entity instances from repositories
- adapt mapping modules for new entities

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c76ded650832ab91e992bcd5b0ba5