### PR TITLE
feat: add recaptcha verification endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DATABASE_URL=postgresql://user:password@localhost:5432/farminx
 PORT=3000
 JWT_SECRET=changeme
 DEBUG=false
+RECAPTCHA_SECRET_KEY=

--- a/src/app.js
+++ b/src/app.js
@@ -10,8 +10,7 @@ const v1CulturesRoutes = require("./routes/v1/cultures.routes");
 const v1StatsRoutes = require("./routes/v1/stats.routes");
 const v1ImportRoutes = require("./routes/v1/import.routes");
 const v1AuthRoutes = require("./routes/v1/auth.routes");
-const userAuthMiddleware = require("./middlewares/user-auth.middleware");
-const appAuthMiddleware = require("./middlewares/app-auth.middleware");
+const recaptchaRoutes = require("./routes/recaptcha.routes");
 const universalAuth = require('./middlewares/auth-universal.middleware');
 const adminOnly = require('./middlewares/role-admin-only');
 
@@ -37,8 +36,10 @@ app.use(
   swaggerUi.setup(swaggerDocV1)
 );
 
-//app.use(userAuthMiddleware); // Middleware d'authentification pour les routes suivantes
-app.use(universalAuth); 
+app.use('/api', recaptchaRoutes);
+
+// Middleware d'authentification pour les routes suivantes
+app.use(universalAuth);
 
 
 app.use("/v1/regions", v1RegionsRoutes);

--- a/src/routes/recaptcha.routes.js
+++ b/src/routes/recaptcha.routes.js
@@ -1,0 +1,50 @@
+const express = require("express");
+const router = express.Router();
+const fetchFn = global.fetch || require("node-fetch");
+
+router.post("/recaptcha", async (req, res) => {
+  try {
+    const { recaptchaToken } = req.body;
+    if (!recaptchaToken) {
+      return res.status(400).json({ error: "Missing recaptchaToken" });
+    }
+
+    const secret = process.env.RECAPTCHA_SECRET_KEY;
+    if (!secret) {
+      return res.status(500).json({ error: "Missing secret key" });
+    }
+
+    const params = new URLSearchParams();
+    params.append("secret", secret);
+    params.append("response", recaptchaToken);
+
+    const response = await fetchFn(
+      "https://www.google.com/recaptcha/api/siteverify",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: params.toString(),
+      }
+    );
+
+    if (!response.ok) {
+      return res.status(500).json({ error: "Recaptcha verification failed" });
+    }
+
+    const data = await response.json();
+    if (!data.success) {
+      return res.status(400).json({ error: "Invalid recaptcha token" });
+    }
+
+    if (typeof data.score === "number" && data.score < 0.5) {
+      return res.status(403).json({ error: "Recaptcha score too low" });
+    }
+
+    return res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+module.exports = router;

--- a/tests/stat.mapping.test.js
+++ b/tests/stat.mapping.test.js
@@ -1,6 +1,3 @@
-const test = require('node:test');
-const assert = require('node:assert');
-
 const { statModelToDto } = require('../src/mapping/stat.mapping');
 const { modelToDto: regionModelToDto } = require('../src/mapping/region.mapping');
 const { modelToDto: cultureModelToDto } = require('../src/mapping/culture.mapping');
@@ -8,40 +5,42 @@ const Region = require('../src/models/region.model');
 const Culture = require('../src/models/culture.model');
 const Stat = require('../src/models/stat.model');
 
-test('statModelToDto converts region and product with mapping', () => {
-  const region = new Region({ id: 1, code: 'R', name: 'Region' });
-  const product = new Culture({ id: 2, name: 'Prod', code: 'P' });
-  const stat = new Stat({
-    id: 3,
-    year: 2024,
-    surfaceHa: 1,
-    yieldQxHa: 2,
-    productionT: 3,
-    granularity: 'region',
-    region,
-    product
+describe('statModelToDto', () => {
+  test('converts region and product with mapping', () => {
+    const region = new Region({ id: 1, code: 'R', name: 'Region' });
+    const product = new Culture({ id: 2, name: 'Prod', code: 'P' });
+    const stat = new Stat({
+      id: 3,
+      year: 2024,
+      surfaceHa: 1,
+      yieldQxHa: 2,
+      productionT: 3,
+      granularity: 'region',
+      region,
+      product
+    });
+
+    const dto = statModelToDto(stat);
+
+    expect(dto.region).toEqual(regionModelToDto(region));
+    expect(dto.product).toEqual(cultureModelToDto(product));
   });
 
-  const dto = statModelToDto(stat);
+  test('handles missing region and product', () => {
+    const stat = new Stat({
+      id: 1,
+      year: 2024,
+      surfaceHa: 0,
+      yieldQxHa: 0,
+      productionT: 0,
+      granularity: 'region',
+      region: null,
+      product: null
+    });
 
-  assert.deepStrictEqual(dto.region, regionModelToDto(region));
-  assert.deepStrictEqual(dto.product, cultureModelToDto(product));
-});
+    const dto = statModelToDto(stat);
 
-test('statModelToDto handles missing region and product', () => {
-  const stat = new Stat({
-    id: 1,
-    year: 2024,
-    surfaceHa: 0,
-    yieldQxHa: 0,
-    productionT: 0,
-    granularity: 'region',
-    region: null,
-    product: null
+    expect(dto.region).toBeNull();
+    expect(dto.product).toBeNull();
   });
-
-  const dto = statModelToDto(stat);
-
-  assert.strictEqual(dto.region, null);
-  assert.strictEqual(dto.product, null);
 });


### PR DESCRIPTION
## Summary
- add `/api/recaptcha` endpoint to validate tokens via Google API
- expose `RECAPTCHA_SECRET_KEY` in env example
- register recaptcha route before auth middleware

## Testing
- `npm test`
- `npx eslint src/routes/recaptcha.routes.js src/app.js tests/stat.mapping.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689127495a4c832a87ef2b9cde637bc5