### PR TITLE
feat: add user profile endpoint

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -10,7 +10,7 @@ exports.login = async (req, res) => {
     if (!user) return res.status(401).json({ error: 'Identifiants invalides' });
     const token = jwt.sign({ id: user.id, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
     res.json(tokenToLoginResponseDto(token));
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: "Erreur lors de l'authentification" });
   }
 };
@@ -21,7 +21,17 @@ exports.register = async (req, res) => {
   try {
     const user = await usersService.createUser({ email, password, firstName, lastName });
     res.status(201).json(userModelToRegisterResponseDto(user));
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: "Erreur lors de la création de l'utilisateur" });
+  }
+};
+
+exports.me = async (req, res) => {
+  try {
+    const user = await usersService.getById(req.user.id);
+    if (!user) return res.status(404).json({ error: 'Utilisateur non trouvé' });
+    res.json(user);
+  } catch {
+    res.status(500).json({ error: "Erreur lors de la récupération de l'utilisateur" });
   }
 };

--- a/src/routes/v1/auth.routes.js
+++ b/src/routes/v1/auth.routes.js
@@ -4,9 +4,11 @@ const authController = require('../../controllers/auth.controller');
 const appsController = require('../../controllers/apps.controller');
 const adminOnly = require('../../middlewares/role-admin-only');
 const universalAuth = require('../../middlewares/auth-universal.middleware');
+const userAuth = require('../../middlewares/user-auth.middleware');
 
 router.post('/login', authController.login);
 router.post('/register', authController.register);
+router.get('/me', userAuth, authController.me);
 
 router.post('/login-app', appsController.loginApp);
 router.post('/register-app', universalAuth, adminOnly({ verifyInDb: true }), appsController.registerApp);

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -16,6 +16,11 @@ exports.createUser = async ({ email, password, firstName, lastName, role = 'user
   return entityToModel(entity);
 };
 
+exports.getById = async (id) => {
+  const user = await usersRepository.findById(id);
+  return entityToModel(user);
+};
+
 exports.isAdmin = async (userId) => {
   const user = await usersRepository.findById(userId);
   return user?.role === 'admin';


### PR DESCRIPTION
## Summary
- add service method to fetch user by ID
- expose `GET /me` endpoint to return authenticated user's profile

## Testing
- `npm test`
- `npm run lint` *(fails: 13 errors, no warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689514281810832aad3f8a59838c8dde