### PR TITLE
feat: add user count endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ const v1CulturesRoutes = require("./routes/v1/cultures.routes");
 const v1StatsRoutes = require("./routes/v1/stats.routes");
 const v1ImportRoutes = require("./routes/v1/import.routes");
 const v1AuthRoutes = require("./routes/v1/auth.routes");
+const v1UsersRoutes = require("./routes/v1/users.routes");
 const recaptchaRoutes = require("./routes/v1/recaptcha.routes");
 const universalAuth = require('./middlewares/auth-universal.middleware');
 const adminOnly = require('./middlewares/role-admin-only');
@@ -45,6 +46,7 @@ app.use(universalAuth);
 app.use("/v1/regions", v1RegionsRoutes);
 app.use("/v1/cultures", v1CulturesRoutes);
 app.use("/v1/stats", v1StatsRoutes);
+app.use("/v1/users", v1UsersRoutes);
 app.use("/v1/import", adminOnly({ verifyInDb: true }), v1ImportRoutes);
 
 app.get("/", (req, res) => res.send("Bienvenue sur l'API Farminx Stats"));

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,0 +1,11 @@
+const usersService = require('../services/users.service');
+
+exports.count = async (req, res) => {
+  try {
+    const count = await usersService.countUsers();
+    res.json({ count });
+  } catch (err) {
+    console.error('Erreur count users:', err);
+    res.status(500).json({ error: "Erreur lors du comptage des utilisateurs" });
+  }
+};

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -7,11 +7,17 @@ exports.findByEmail = async (email) => {
 };
 
 exports.createUser = async ({ email, passwordHash, firstName, lastName, role }) => {
-  const row = await prisma.users.create({ data: { email, password_hash: passwordHash, first_name: firstName, last_name: lastName, role } });
+  const row = await prisma.users.create({
+    data: { email, password_hash: passwordHash, first_name: firstName, last_name: lastName, role },
+  });
   return new UserEntity(row);
 };
 
 exports.findById = async (id) => {
   const row = await prisma.users.findUnique({ where: { id } });
   return row ? new UserEntity(row) : null;
+};
+
+exports.countAll = async () => {
+  return prisma.users.count();
 };

--- a/src/routes/v1/users.routes.js
+++ b/src/routes/v1/users.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const usersController = require("../../controllers/users.controller");
+const userAuth = require("../../middlewares/user-auth.middleware");
+const adminOnly = require("../../middlewares/role-admin-only");
+
+router.get("/count", userAuth, adminOnly(), usersController.count);
+
+module.exports = router;

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -25,3 +25,7 @@ exports.isAdmin = async (userId) => {
   const user = await usersRepository.findById(userId);
   return user?.role === 'admin';
 };
+
+exports.countUsers = async () => {
+  return usersRepository.countAll();
+};


### PR DESCRIPTION
## Summary
- add repository method to count users
- expose users count in service and controller
- secure GET /v1/users/count route for admins

## Testing
- `npm test`
- `npm run lint` *(fails: 'err' is defined but never used, 'recaptcha' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6895315fbb84832a8466bee0a8f310da