### PR TITLE
feat: add notification preferences

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -813,6 +813,64 @@
           }
         }
       }
+    },
+    "/notifications": {
+      "get": {
+        "summary": "Récupérer les préférences de notification",
+        "tags": [
+          "Notifications"
+        ],
+        "responses": {
+          "200": {
+            "description": "Préférences de notification",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notification"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notifications/subscribe": {
+      "post": {
+        "summary": "Mettre à jour les préférences de notification",
+        "tags": [
+          "Notifications"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "stats": {
+                    "type": "boolean"
+                  },
+                  "marketplace": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Préférences de notification",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Notification"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1037,6 +1095,29 @@
           "email": {
             "type": "string",
             "format": "email"
+          }
+        }
+      },
+      "Notification": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "stats": {
+            "type": "boolean"
+          },
+          "marketplace": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,7 @@ model users {
   created_at    DateTime @default(now())
   announcements announcements[]
   favorites     favorites[]
+  notifications notifications?
 }
 
 model announcements {
@@ -109,4 +110,13 @@ model api_app {
   secret    String?
   apiKey    String?   @unique
   createdAt DateTime @default(now())
+}
+
+model notifications {
+  id          String   @id @default(uuid()) @db.Uuid
+  user_id     String   @unique @db.Uuid
+  stats       Boolean  @default(false)
+  marketplace Boolean  @default(false)
+  created_at  DateTime @default(now())
+  users       users    @relation(fields: [user_id], references: [id])
 }

--- a/src/app.js
+++ b/src/app.js
@@ -11,6 +11,7 @@ const v1StatsRoutes = require("./routes/v1/stats.routes");
 const v1ImportRoutes = require("./routes/v1/import.routes");
 const v1AuthRoutes = require("./routes/v1/auth.routes");
 const v1UsersRoutes = require("./routes/v1/users.routes");
+const v1NotificationsRoutes = require("./routes/v1/notifications.routes");
 const recaptchaRoutes = require("./routes/v1/recaptcha.routes");
 const universalAuth = require('./middlewares/auth-universal.middleware');
 const adminOnly = require('./middlewares/role-admin-only');
@@ -48,6 +49,7 @@ app.use("/v1/cultures", v1CulturesRoutes);
 app.use("/v1/stats", v1StatsRoutes);
 app.use("/v1/users", v1UsersRoutes);
 app.use("/v1/import", adminOnly({ verifyInDb: true }), v1ImportRoutes);
+app.use("/v1/notifications", v1NotificationsRoutes);
 
 app.get("/", (req, res) => res.send("Bienvenue sur l'API Farminx Stats"));
 

--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -1,0 +1,22 @@
+const notificationsService = require('../services/notifications.service');
+
+exports.subscribe = async (req, res) => {
+  try {
+    const { stats = false, marketplace = false } = req.body || {};
+    const preferences = await notificationsService.subscribe(req.user.id, { stats, marketplace });
+    res.json(preferences);
+  } catch (err) {
+    console.error('Erreur subscribe notifications:', err);
+    res.status(500).json({ error: "Erreur lors de la mise à jour des préférences de notification" });
+  }
+};
+
+exports.get = async (req, res) => {
+  try {
+    const preferences = await notificationsService.getPreferences(req.user.id);
+    res.json(preferences);
+  } catch (err) {
+    console.error('Erreur get notifications:', err);
+    res.status(500).json({ error: "Erreur lors de la récupération des préférences de notification" });
+  }
+};

--- a/src/entities/notification.entity.js
+++ b/src/entities/notification.entity.js
@@ -1,0 +1,11 @@
+class NotificationEntity {
+  constructor({ id, user_id, stats, marketplace, created_at }) {
+    this.id = id;
+    this.user_id = user_id;
+    this.stats = stats;
+    this.marketplace = marketplace;
+    this.created_at = created_at;
+  }
+}
+
+module.exports = NotificationEntity;

--- a/src/mapping/notification.mapping.js
+++ b/src/mapping/notification.mapping.js
@@ -1,0 +1,14 @@
+const Notification = require('../models/notification.model');
+
+function entityToModel(entity) {
+  if (!entity) return null;
+  return new Notification({
+    id: entity.id,
+    userId: entity.user_id,
+    stats: entity.stats,
+    marketplace: entity.marketplace,
+    createdAt: entity.created_at,
+  });
+}
+
+module.exports = { entityToModel };

--- a/src/models/notification.model.js
+++ b/src/models/notification.model.js
@@ -1,0 +1,11 @@
+class Notification {
+  constructor({ id, userId, stats, marketplace, createdAt }) {
+    this.id = id;
+    this.userId = userId;
+    this.stats = stats;
+    this.marketplace = marketplace;
+    this.createdAt = createdAt;
+  }
+}
+
+module.exports = Notification;

--- a/src/repositories/notifications.repository.js
+++ b/src/repositories/notifications.repository.js
@@ -1,0 +1,16 @@
+const prisma = require('../config/prisma');
+const NotificationEntity = require('../entities/notification.entity');
+
+exports.upsert = async ({ userId, stats = false, marketplace = false }) => {
+  const row = await prisma.notifications.upsert({
+    where: { user_id: userId },
+    update: { stats, marketplace },
+    create: { user_id: userId, stats, marketplace },
+  });
+  return new NotificationEntity(row);
+};
+
+exports.findByUserId = async (userId) => {
+  const row = await prisma.notifications.findUnique({ where: { user_id: userId } });
+  return row ? new NotificationEntity(row) : null;
+};

--- a/src/routes/v1/notifications.routes.js
+++ b/src/routes/v1/notifications.routes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const notificationsController = require('../../controllers/notifications.controller');
+
+router.post('/subscribe', notificationsController.subscribe);
+router.get('/', notificationsController.get);
+
+module.exports = router;

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -1,0 +1,12 @@
+const notificationsRepository = require('../repositories/notifications.repository');
+const { entityToModel } = require('../mapping/notification.mapping');
+
+exports.subscribe = async (userId, { stats = false, marketplace = false }) => {
+  const entity = await notificationsRepository.upsert({ userId, stats, marketplace });
+  return entityToModel(entity);
+};
+
+exports.getPreferences = async (userId) => {
+  const entity = await notificationsRepository.findByUserId(userId);
+  return entityToModel(entity);
+};


### PR DESCRIPTION
## Summary
- add notifications table for user preferences
- expose stats and marketplace flags through entity, model, and mapping
- implement repository/service/controller/routes for notification preferences
- document notifications endpoints in Swagger

## Testing
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npm run migrate` *(prompts to install prisma package)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6898fe3782ec832aa0ba553f7a6985b1