### PR TITLE
feat: send admin notification emails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
         "nanoid": "^5.1.5",
+        "nodemailer": "^6.10.1",
         "prisma": "^5.0.0",
         "swagger-ui-express": "^4.6.3"
       },
@@ -5798,6 +5799,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.2",
     "nanoid": "^5.1.5",
+    "nodemailer": "^6.10.1",
     "prisma": "^5.0.0",
     "swagger-ui-express": "^4.6.3"
   },

--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -1,4 +1,5 @@
 const notificationsService = require('../services/notifications.service');
+const emailService = require('../services/email.service');
 
 exports.subscribe = async (req, res) => {
   try {
@@ -18,5 +19,17 @@ exports.get = async (req, res) => {
   } catch (err) {
     console.error('Erreur get notifications:', err);
     res.status(500).json({ error: "Erreur lors de la récupération des préférences de notification" });
+  }
+};
+
+exports.adminSend = async (req, res) => {
+  try {
+    const { stats = false, marketplace = false, subject, body } = req.body || {};
+    const emails = await emailService.getSubscribedEmails({ stats, marketplace });
+    const result = await emailService.sendBulkEmail(emails, subject, body);
+    res.json(result);
+  } catch (err) {
+    console.error('Erreur envoi notifications admin:', err);
+    res.status(500).json({ error: "Erreur lors de l'envoi des notifications" });
   }
 };

--- a/src/repositories/notifications.repository.js
+++ b/src/repositories/notifications.repository.js
@@ -14,3 +14,16 @@ exports.findByUserId = async (userId) => {
   const row = await prisma.notifications.findUnique({ where: { user_id: userId } });
   return row ? new NotificationEntity(row) : null;
 };
+
+exports.findSubscribed = async ({ stats = false, marketplace = false }) => {
+  const or = [];
+  if (stats) or.push({ stats: true });
+  if (marketplace) or.push({ marketplace: true });
+  if (!or.length) return [];
+
+  const rows = await prisma.notifications.findMany({
+    where: { OR: or },
+    select: { user_id: true },
+  });
+  return rows.map((r) => r.user_id);
+};

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -21,3 +21,9 @@ exports.findById = async (id) => {
 exports.countAll = async () => {
   return prisma.users.count();
 };
+
+exports.listByIds = async (ids) => {
+  if (!ids.length) return [];
+  const rows = await prisma.users.findMany({ where: { id: { in: ids } } });
+  return rows.map((row) => new UserEntity(row));
+};

--- a/src/routes/v1/notifications.routes.js
+++ b/src/routes/v1/notifications.routes.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 const notificationsController = require('../../controllers/notifications.controller');
 const userAuth = require('../../middlewares/user-auth.middleware');
+const roleAdminOnly = require('../../middlewares/role-admin-only');
 
 
 router.post('/subscribe', userAuth, notificationsController.subscribe);
 router.get('/', userAuth, notificationsController.get);
+router.post('/admin/send', userAuth, roleAdminOnly({ verifyInDb: false }), notificationsController.adminSend);
 
 module.exports = router;

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -1,0 +1,41 @@
+const nodemailer = require('nodemailer');
+const notificationsRepository = require('../repositories/notifications.repository');
+const usersRepository = require('../repositories/users.repository');
+
+exports.getSubscribedEmails = async ({ stats = false, marketplace = false }) => {
+  const userIds = await notificationsRepository.findSubscribed({ stats, marketplace });
+  if (!userIds.length) return [];
+  const users = await usersRepository.listByIds(userIds);
+  return users.map((u) => u.email);
+};
+
+const transporter = nodemailer.createTransport({
+  host: process.env.EMAIL_HOST,
+  port: process.env.EMAIL_PORT,
+  secure: process.env.EMAIL_SECURE === 'true',
+  auth: process.env.EMAIL_USER
+    ? {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASSWORD,
+      }
+    : undefined,
+});
+
+exports.sendBulkEmail = async (addresses, subject, body) => {
+  const result = { sent: [], failed: [] };
+  for (const addr of addresses) {
+    try {
+      await transporter.sendMail({
+        from: process.env.EMAIL_FROM,
+        to: addr,
+        subject,
+        text: body,
+      });
+      result.sent.push(addr);
+    } catch (err) {
+      console.error('Erreur envoi email vers', addr, err);
+      result.failed.push(addr);
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
## Summary
- list users with active notification preferences
- send bulk emails via nodemailer
- expose secured admin endpoint to dispatch notifications

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a639c513c832a803396cb0039538c