### PR TITLE
feat: expose notification details for users

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -809,6 +809,8 @@
                       "email": { "type": "string" },
                       "firstName": { "type": "string", "nullable": true },
                       "lastName": { "type": "string", "nullable": true },
+                      "statsSubscribed": { "type": "boolean" },
+                      "marketplaceSubscribed": { "type": "boolean" },
                       "subscribed": { "type": "boolean" },
                       "subscriptionDate": { "type": "string", "format": "date-time", "nullable": true }
                     }

--- a/docs/v2/swagger.json
+++ b/docs/v2/swagger.json
@@ -26,6 +26,8 @@
                       "email": { "type": "string" },
                       "firstName": { "type": "string", "nullable": true },
                       "lastName": { "type": "string", "nullable": true },
+                      "statsSubscribed": { "type": "boolean" },
+                      "marketplaceSubscribed": { "type": "boolean" },
                       "subscribed": { "type": "boolean" },
                       "subscriptionDate": { "type": "string", "format": "date-time", "nullable": true }
                     }

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -28,14 +28,21 @@ exports.isAdmin = async (userId) => {
 
 exports.listUsersWithNotifications = async () => {
   const rows = await usersRepository.listAllWithNotifications();
-  return rows.map(({ user, notification }) => ({
-    id: user.id,
-    email: user.email,
-    firstName: user.first_name,
-    lastName: user.last_name,
-    subscribed: Boolean(notification?.stats || notification?.marketplace),
-    subscriptionDate: notification?.created_at,
-  }));
+  return rows.map(({ user, notification }) => {
+    const statsSubscribed = Boolean(notification?.stats);
+    const marketplaceSubscribed = Boolean(notification?.marketplace);
+
+    return {
+      id: user.id,
+      email: user.email,
+      firstName: user.first_name,
+      lastName: user.last_name,
+      statsSubscribed,
+      marketplaceSubscribed,
+      subscribed: statsSubscribed || marketplaceSubscribed,
+      subscriptionDate: notification?.created_at,
+    };
+  });
 };
 
 exports.countUsers = async () => {

--- a/tests/users.routes.test.js
+++ b/tests/users.routes.test.js
@@ -79,6 +79,8 @@ describe('GET /v1/users', () => {
         email: 'user2@test.com',
         firstName: 'Jane',
         lastName: 'Doe',
+        statsSubscribed: true,
+        marketplaceSubscribed: false,
         subscribed: true,
         subscriptionDate: '2024-06-01T00:00:00.000Z',
       },


### PR DESCRIPTION
## Summary
- return detailed subscription flags for users
- document stats and marketplace subscription flags
- adjust user route tests for new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b94ec2780832a9bdcee8b84916fd0