### PR TITLE
feat: paginate users endpoint

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -795,24 +795,46 @@
         "tags": [
           "Users"
         ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 1 },
+            "description": "Numéro de page"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 50 },
+            "description": "Nombre d'éléments par page"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Liste des utilisateurs avec statut d'abonnement",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": { "type": "string" },
-                      "email": { "type": "string" },
-                      "firstName": { "type": "string", "nullable": true },
-                      "lastName": { "type": "string", "nullable": true },
-                      "statsSubscribed": { "type": "boolean" },
-                      "marketplaceSubscribed": { "type": "boolean" },
-                      "subscribed": { "type": "boolean" },
-                      "subscriptionDate": { "type": "string", "format": "date-time", "nullable": true }
+                  "type": "object",
+                  "properties": {
+                    "total": { "type": "integer" },
+                    "page": { "type": "integer" },
+                    "limit": { "type": "integer" },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "email": { "type": "string" },
+                          "firstName": { "type": "string", "nullable": true },
+                          "lastName": { "type": "string", "nullable": true },
+                          "statsSubscribed": { "type": "boolean" },
+                          "marketplaceSubscribed": { "type": "boolean" },
+                          "subscribed": { "type": "boolean" },
+                          "subscriptionDate": { "type": "string", "format": "date-time", "nullable": true }
+                        }
+                      }
                     }
                   }
                 }

--- a/docs/v2/swagger.json
+++ b/docs/v2/swagger.json
@@ -12,24 +12,46 @@
         "tags": [
           "Users"
         ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 1 },
+            "description": "Numéro de page"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 50 },
+            "description": "Nombre d'éléments par page"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Liste des utilisateurs avec statut d'abonnement",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": { "type": "string" },
-                      "email": { "type": "string" },
-                      "firstName": { "type": "string", "nullable": true },
-                      "lastName": { "type": "string", "nullable": true },
-                      "statsSubscribed": { "type": "boolean" },
-                      "marketplaceSubscribed": { "type": "boolean" },
-                      "subscribed": { "type": "boolean" },
-                      "subscriptionDate": { "type": "string", "format": "date-time", "nullable": true }
+                  "type": "object",
+                  "properties": {
+                    "total": { "type": "integer" },
+                    "page": { "type": "integer" },
+                    "limit": { "type": "integer" },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "email": { "type": "string" },
+                          "firstName": { "type": "string", "nullable": true },
+                          "lastName": { "type": "string", "nullable": true },
+                          "statsSubscribed": { "type": "boolean" },
+                          "marketplaceSubscribed": { "type": "boolean" },
+                          "subscribed": { "type": "boolean" },
+                          "subscriptionDate": { "type": "string", "format": "date-time", "nullable": true }
+                        }
+                      }
                     }
                   }
                 }

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -12,8 +12,10 @@ exports.count = async (req, res) => {
 
 exports.list = async (req, res) => {
   try {
-    const users = await usersService.listUsersWithNotifications();
-    res.json(users);
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 50;
+    const result = await usersService.listUsersWithNotifications({ page, limit });
+    res.json(result);
   } catch (err) {
     console.error('Erreur list users:', err);
     res.status(500).json({ error: 'Erreur lors de la récupération des utilisateurs' });

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -26,9 +26,9 @@ exports.isAdmin = async (userId) => {
   return user?.role === 'admin';
 };
 
-exports.listUsersWithNotifications = async () => {
-  const rows = await usersRepository.listAllWithNotifications();
-  return rows.map(({ user, notification }) => {
+exports.listUsersWithNotifications = async ({ page = 1, limit = 50 } = {}) => {
+  const { rows, total } = await usersRepository.listAllWithNotifications({ page, limit });
+  const data = rows.map(({ user, notification }) => {
     const statsSubscribed = Boolean(notification?.stats);
     const marketplaceSubscribed = Boolean(notification?.marketplace);
 
@@ -43,6 +43,8 @@ exports.listUsersWithNotifications = async () => {
       subscriptionDate: notification?.created_at,
     };
   });
+
+  return { total, page, limit, data };
 };
 
 exports.countUsers = async () => {


### PR DESCRIPTION
## Summary
- add pagination support to GET /v1/users
- document pagination parameters and response structure in swagger files
- update tests for new paginated response

## Testing
- `npm test` *(fails: @prisma/client did not initialize)*
- `npx prisma generate` *(fails: 403 fetching Prisma engine)*
- `npm run lint` *(fails: 14 lint errors in unrelated files)*
- `npx eslint src/controllers/users.controller.js src/services/users.service.js src/repositories/users.repository.js tests/users.routes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689b9b25e6ec832ab2c3f927f24ff71e