### PR TITLE
docs: document admin notification endpoint

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -926,6 +926,52 @@
           }
         }
       }
+    },
+    "/notifications/admin/send": {
+      "post": {
+        "summary": "Envoyer des notifications aux abonnés",
+        "tags": [
+          "Notifications"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "subject": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subject",
+                  "body"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Notifications envoyées avec succès"
+          },
+          "403": {
+            "description": "Non autorisé"
+          },
+          "500": {
+            "description": "Erreur serveur"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/docs/v2/swagger.json
+++ b/docs/v2/swagger.json
@@ -60,6 +60,39 @@
           }
         }
       }
+    },
+    "/notifications/admin/send": {
+      "post": {
+        "summary": "Envoyer des notifications aux abonnés",
+        "tags": [
+          "Notifications"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "subject": { "type": "string" },
+                  "body": { "type": "string" }
+                },
+                "required": ["subject", "body"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Notifications envoyées avec succès" },
+          "403": { "description": "Non autorisé" },
+          "500": { "description": "Erreur serveur" }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- document `/notifications/admin/send` endpoint in swagger v1 and v2

## Testing
- `npm test`
- `npm run lint` *(fails: 'err' is defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689baa58ae94832a86291b9f4b0ee207