### PR TITLE
Include user role in user listing

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -829,6 +829,7 @@
                           "email": { "type": "string" },
                           "firstName": { "type": "string", "nullable": true },
                           "lastName": { "type": "string", "nullable": true },
+                          "role": { "type": "string", "description": "Rôle de l'utilisateur" },
                           "statsSubscribed": { "type": "boolean" },
                           "marketplaceSubscribed": { "type": "boolean" },
                           "subscribed": { "type": "boolean" },

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -37,6 +37,7 @@ exports.listUsersWithNotifications = async ({ page = 1, limit = 50 } = {}) => {
       email: user.email,
       firstName: user.first_name,
       lastName: user.last_name,
+      role: user.role,
       statsSubscribed,
       marketplaceSubscribed,
       subscribed: statsSubscribed || marketplaceSubscribed,

--- a/tests/users.routes.test.js
+++ b/tests/users.routes.test.js
@@ -89,6 +89,7 @@ describe('GET /v1/users', () => {
           email: 'user2@test.com',
           firstName: 'Jane',
           lastName: 'Doe',
+          role: 'user',
           statsSubscribed: true,
           marketplaceSubscribed: false,
           subscribed: true,
@@ -96,5 +97,6 @@ describe('GET /v1/users', () => {
         },
       ],
     });
+    expect(res.body.data[0].role).toBe('user');
   });
 });


### PR DESCRIPTION
## Summary
- include role field in user listing service
- document role in /users swagger response
- test that role is returned in user list

## Testing
- `npm test`
- `npm run lint` *(fails: 'StatEntity' is assigned a value but never used, 'CultureSummaryEntity' is assigned a value but never used, 'UserEntity' is assigned a value but never used, 'err' is defined but never used, 'recaptcha' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689cd7c041f4832a921c93fd291949a3