### PR TITLE
feat: add user deletion endpoint

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -844,6 +844,27 @@
         }
       }
     },
+    "/users/{id}": {
+      "delete": {
+        "summary": "Supprimer un utilisateur",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "description": "ID de l'utilisateur à supprimer"
+          }
+        ],
+        "responses": {
+          "204": { "description": "Utilisateur supprimé" },
+          "404": { "description": "Utilisateur non trouvé" }
+        }
+      }
+    },
     "/users/count": {
       "get": {
         "summary": "Nombre total d'utilisateurs",

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -21,3 +21,15 @@ exports.list = async (req, res) => {
     res.status(500).json({ error: 'Erreur lors de la récupération des utilisateurs' });
   }
 };
+
+exports.remove = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deleted = await usersService.deleteUser(id);
+    if (!deleted) return res.status(404).json({ error: "Utilisateur non trouvé" });
+    res.status(204).send();
+  } catch (err) {
+    console.error('Erreur suppression user:', err);
+    res.status(500).json({ error: "Erreur lors de la suppression de l'utilisateur" });
+  }
+};

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -19,6 +19,11 @@ exports.findById = async (id) => {
   return row ? new UserEntity(row) : null;
 };
 
+exports.deleteById = async (id) => {
+  const row = await prisma.users.delete({ where: { id } });
+  return row ? new UserEntity(row) : null;
+};
+
 exports.countAll = async () => {
   return prisma.users.count();
 };

--- a/src/routes/v1/users.routes.js
+++ b/src/routes/v1/users.routes.js
@@ -6,5 +6,6 @@ const adminOnly = require("../../middlewares/role-admin-only");
 
 router.get("/", userAuth, adminOnly(), usersController.list);
 router.get("/count", userAuth, adminOnly(), usersController.count);
+router.delete("/:id", userAuth, adminOnly(), usersController.remove);
 
 module.exports = router;

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -21,6 +21,16 @@ exports.getById = async (id) => {
   return entityToModel(user);
 };
 
+exports.deleteUser = async (id) => {
+  try {
+    const entity = await usersRepository.deleteById(id);
+    return entityToModel(entity);
+  } catch (err) {
+    if (err.code === 'P2025') return null;
+    throw err;
+  }
+};
+
 exports.isAdmin = async (userId) => {
   const user = await usersRepository.findById(userId);
   return user?.role === 'admin';

--- a/tests/users.routes.test.js
+++ b/tests/users.routes.test.js
@@ -98,3 +98,75 @@ describe('GET /v1/users', () => {
     });
   });
 });
+
+describe('DELETE /v1/users/:id', () => {
+  test('requires admin role', async () => {
+    usersRepository.findById.mockResolvedValue(
+      new UserEntity({
+        id: 'u1',
+        email: 'user@test.com',
+        password_hash: 'hash',
+        first_name: 'User',
+        last_name: 'Test',
+        role: 'user',
+        created_at: new Date(),
+      })
+    );
+    const token = jwt.sign({ id: 'u1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .delete('/v1/users/u2')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  test('returns 204 when user deleted', async () => {
+    usersRepository.findById.mockResolvedValue(
+      new UserEntity({
+        id: 'a1',
+        email: 'admin@test.com',
+        password_hash: 'hash',
+        first_name: 'Admin',
+        last_name: 'Test',
+        role: 'admin',
+        created_at: new Date(),
+      })
+    );
+    usersRepository.deleteById.mockResolvedValue(
+      new UserEntity({
+        id: 'u2',
+        email: 'user2@test.com',
+        password_hash: 'hash',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        role: 'user',
+        created_at: new Date(),
+      })
+    );
+    const token = jwt.sign({ id: 'a1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .delete('/v1/users/u2')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(204);
+    expect(usersRepository.deleteById).toHaveBeenCalledWith('u2');
+  });
+
+  test('returns 404 when user not found', async () => {
+    usersRepository.findById.mockResolvedValue(
+      new UserEntity({
+        id: 'a1',
+        email: 'admin@test.com',
+        password_hash: 'hash',
+        first_name: 'Admin',
+        last_name: 'Test',
+        role: 'admin',
+        created_at: new Date(),
+      })
+    );
+    usersRepository.deleteById.mockRejectedValue({ code: 'P2025' });
+    const token = jwt.sign({ id: 'a1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .delete('/v1/users/u2')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary
- add repository method to delete user by id
- expose deleteUser service and controller remove handler
- document DELETE /users/{id} endpoint and cover route tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd7bccd34832ab9994571fed566c6