### PR TITLE
feat: support admin notification query filters

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -960,6 +960,22 @@
             "bearerAuth": []
           }
         ],
+        "parameters": [
+          {
+            "name": "stats",
+            "in": "query",
+            "schema": { "type": "boolean" },
+            "required": false,
+            "description": "Send to stats subscribers when true. At least one of stats or marketplace must be true."
+          },
+          {
+            "name": "marketplace",
+            "in": "query",
+            "schema": { "type": "boolean" },
+            "required": false,
+            "description": "Send to marketplace subscribers when true. At least one of stats or marketplace must be true."
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {

--- a/docs/v2/swagger.json
+++ b/docs/v2/swagger.json
@@ -72,6 +72,22 @@
             "bearerAuth": []
           }
         ],
+        "parameters": [
+          {
+            "name": "stats",
+            "in": "query",
+            "schema": { "type": "boolean" },
+            "required": false,
+            "description": "Send to stats subscribers when true. At least one of stats or marketplace must be true."
+          },
+          {
+            "name": "marketplace",
+            "in": "query",
+            "schema": { "type": "boolean" },
+            "required": false,
+            "description": "Send to marketplace subscribers when true. At least one of stats or marketplace must be true."
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {

--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -24,8 +24,12 @@ exports.get = async (req, res) => {
 
 exports.adminSend = async (req, res) => {
   try {
-    const { stats = false, marketplace = false, subject, body } = req.body || {};
-    const emails = await emailService.getSubscribedEmails({ stats, marketplace });
+    const { subject, body } = req.body || {};
+    const { stats, marketplace } = req.query || {};
+    const emails = await emailService.getSubscribedEmails({
+      stats: stats === 'true',
+      marketplace: marketplace === 'true'
+    });
     const result = await emailService.sendBulkEmail(emails, subject, body);
     res.json(result);
   } catch (err) {

--- a/src/routes/v1/notifications.routes.js
+++ b/src/routes/v1/notifications.routes.js
@@ -7,6 +7,10 @@ const roleAdminOnly = require('../../middlewares/role-admin-only');
 
 router.post('/subscribe', userAuth, notificationsController.subscribe);
 router.get('/', userAuth, notificationsController.get);
+// Optional query params:
+//   stats=true to email stats subscribers
+//   marketplace=true to email marketplace subscribers
+//   at least one must be true to send any emails
 router.post('/admin/send', userAuth, roleAdminOnly({ verifyInDb: false }), notificationsController.adminSend);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow admin notifications to specify `stats` and `marketplace` via query parameters
- document optional notification query parameters and usage

## Testing
- `npm test`
- `npm run lint` *(fails: existing repository lint errors)*
- `npx eslint src/controllers/notifications.controller.js src/routes/v1/notifications.routes.js`

------
https://chatgpt.com/codex/tasks/task_e_689cdf94a1e0832ab709e6b7512f983e