### PR TITLE
refactor: switch email service to Gmail OAuth2

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -10,15 +10,14 @@ exports.getSubscribedEmails = async ({ stats = false, marketplace = false }) => 
 };
 
 const transporter = nodemailer.createTransport({
-  host: process.env.EMAIL_HOST,
-  port: process.env.EMAIL_PORT,
-  secure: process.env.EMAIL_SECURE === 'true',
-  auth: process.env.EMAIL_USER
-    ? {
-        user: process.env.EMAIL_USER,
-        pass: process.env.EMAIL_PASSWORD,
-      }
-    : undefined,
+  service: 'gmail',
+  auth: {
+    type: 'OAuth2',
+    user: process.env.EMAIL_USER,
+    clientId: process.env.GOOGLE_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    refreshToken: process.env.GOOGLE_REFRESH_TOKEN,
+  },
 });
 
 exports.sendBulkEmail = async (addresses, subject, body) => {
@@ -26,7 +25,7 @@ exports.sendBulkEmail = async (addresses, subject, body) => {
   for (const addr of addresses) {
     try {
       await transporter.sendMail({
-        from: process.env.EMAIL_FROM,
+        from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
         to: addr,
         subject,
         text: body,

--- a/tests/email.service.test.js
+++ b/tests/email.service.test.js
@@ -1,0 +1,69 @@
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(),
+}));
+let nodemailer;
+
+describe('email.service', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    nodemailer = require('nodemailer');
+  });
+
+  test('creates Gmail OAuth2 transporter', () => {
+    process.env.EMAIL_USER = 'user@gmail.com';
+    process.env.GOOGLE_CLIENT_ID = 'clientId';
+    process.env.GOOGLE_CLIENT_SECRET = 'clientSecret';
+    process.env.GOOGLE_REFRESH_TOKEN = 'refresh';
+
+    require('../src/services/email.service');
+
+    expect(nodemailer.createTransport).toHaveBeenCalledWith({
+      service: 'gmail',
+      auth: {
+        type: 'OAuth2',
+        user: process.env.EMAIL_USER,
+        clientId: process.env.GOOGLE_CLIENT_ID,
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+        refreshToken: process.env.GOOGLE_REFRESH_TOKEN,
+      },
+    });
+  });
+
+  test('sendBulkEmail uses EMAIL_USER when EMAIL_FROM missing', async () => {
+    process.env.EMAIL_USER = 'user@gmail.com';
+    delete process.env.EMAIL_FROM;
+    const sendMail = jest.fn().mockResolvedValue();
+    nodemailer.createTransport.mockReturnValue({ sendMail });
+
+    const emailService = require('../src/services/email.service');
+
+    await emailService.sendBulkEmail(['a@test.com'], 'subject', 'body');
+
+    expect(sendMail).toHaveBeenCalledWith({
+      from: process.env.EMAIL_USER,
+      to: 'a@test.com',
+      subject: 'subject',
+      text: 'body',
+    });
+  });
+
+  test('sendBulkEmail uses EMAIL_FROM when defined', async () => {
+    process.env.EMAIL_USER = 'user@gmail.com';
+    process.env.EMAIL_FROM = 'Farm <farm@example.com>';
+    const sendMail = jest.fn().mockResolvedValue();
+    nodemailer.createTransport.mockReturnValue({ sendMail });
+
+    const emailService = require('../src/services/email.service');
+
+    await emailService.sendBulkEmail(['a@test.com'], 'subject', 'body');
+
+    expect(sendMail).toHaveBeenCalledWith({
+      from: process.env.EMAIL_FROM,
+      to: 'a@test.com',
+      subject: 'subject',
+      text: 'body',
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace SMTP credentials with Gmail OAuth2 transport
- default email sender to `EMAIL_FROM` or `EMAIL_USER`
- cover email service with OAuth2 aware unit tests

## Testing
- `npm test`
- `npm run lint` *(fails: 'recaptcha' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a36b668520832aaf510f94a2b8a2d9