### PR TITLE
feat: add password change endpoint

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -591,6 +591,48 @@
         }
       }
     },
+    "/auth/change-password": {
+      "post": {
+        "summary": "Changer le mot de passe",
+        "tags": [
+          "Authentification"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "oldPassword",
+                  "newPassword"
+                ],
+                "properties": {
+                  "oldPassword": {
+                    "type": "string"
+                  },
+                  "newPassword": {
+                    "type": "string",
+                    "minLength": 6
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Mot de passe mis à jour"
+          },
+          "400": {
+            "description": "Requête invalide"
+          },
+          "401": {
+            "description": "Ancien mot de passe incorrect"
+          }
+        }
+      }
+    },
     "/auth/login-app": {
       "post": {
         "summary": "Connexion d'une application enregistrée",

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -35,3 +35,18 @@ exports.me = async (req, res) => {
     res.status(500).json({ error: "Erreur lors de la récupération de l'utilisateur" });
   }
 };
+
+exports.changePassword = async (req, res) => {
+  const { oldPassword, newPassword } = req.body;
+  if (!oldPassword || !newPassword)
+    return res.status(400).json({ error: 'Ancien et nouveau mot de passe requis' });
+  if (newPassword.length < 6)
+    return res.status(400).json({ error: 'Nouveau mot de passe trop court' });
+  try {
+    const ok = await usersService.changePassword(req.user.id, oldPassword, newPassword);
+    if (!ok) return res.status(401).json({ error: 'Ancien mot de passe incorrect' });
+    return res.sendStatus(204);
+  } catch {
+    return res.status(500).json({ error: 'Erreur lors du changement de mot de passe' });
+  }
+};

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -24,6 +24,14 @@ exports.deleteById = async (id) => {
   return row ? new UserEntity(row) : null;
 };
 
+exports.updatePassword = async (id, passwordHash) => {
+  const row = await prisma.users.update({
+    where: { id },
+    data: { password_hash: passwordHash },
+  });
+  return row ? new UserEntity(row) : null;
+};
+
 exports.countAll = async () => {
   return prisma.users.count();
 };

--- a/src/routes/v1/auth.routes.js
+++ b/src/routes/v1/auth.routes.js
@@ -9,6 +9,7 @@ const userAuth = require('../../middlewares/user-auth.middleware');
 router.post('/login', authController.login);
 router.post('/register', authController.register);
 router.get('/me', userAuth, authController.me);
+router.post('/change-password', userAuth, authController.changePassword);
 
 router.post('/login-app', appsController.loginApp);
 router.post('/register-app', universalAuth, adminOnly({ verifyInDb: true }), appsController.registerApp);

--- a/src/services/users.service.js
+++ b/src/services/users.service.js
@@ -36,6 +36,16 @@ exports.isAdmin = async (userId) => {
   return user?.role === 'admin';
 };
 
+exports.changePassword = async (id, oldPassword, newPassword) => {
+  const user = await usersRepository.findById(id);
+  if (!user) return false;
+  const match = await bcrypt.compare(oldPassword, user.password_hash);
+  if (!match) return false;
+  const passwordHash = await bcrypt.hash(newPassword, 15);
+  await usersRepository.updatePassword(id, passwordHash);
+  return true;
+};
+
 exports.listUsersWithNotifications = async ({ page = 1, limit = 50 } = {}) => {
   const { rows, total } = await usersRepository.listAllWithNotifications({ page, limit });
   const data = rows.map(({ user, notification }) => {

--- a/tests/auth.change-password.test.js
+++ b/tests/auth.change-password.test.js
@@ -1,0 +1,58 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+jest.mock('../src/services/users.service');
+jest.mock('../src/controllers/apps.controller', () => ({
+  loginApp: jest.fn(),
+  registerApp: jest.fn(),
+  registerAppApiKey: jest.fn(),
+}));
+jest.mock('../src/middlewares/auth-universal.middleware', () => jest.fn((req, res, next) => next()));
+const usersService = require('../src/services/users.service');
+const authRouter = require('../src/routes/v1/auth.routes');
+
+let app;
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+  app = express();
+  app.use(express.json());
+  app.use('/v1/auth', authRouter);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /v1/auth/change-password', () => {
+  test('successfully changes password', async () => {
+    usersService.changePassword.mockResolvedValue(true);
+    const token = jwt.sign({ id: 'u1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/v1/auth/change-password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ oldPassword: 'old', newPassword: 'newpass' });
+    expect(res.status).toBe(204);
+    expect(usersService.changePassword).toHaveBeenCalledWith('u1', 'old', 'newpass');
+  });
+
+  test('returns 400 when parameters missing', async () => {
+    const token = jwt.sign({ id: 'u1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/v1/auth/change-password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ oldPassword: 'old' });
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 401 when old password is wrong', async () => {
+    usersService.changePassword.mockResolvedValue(false);
+    const token = jwt.sign({ id: 'u1' }, process.env.JWT_SECRET);
+    const res = await request(app)
+      .post('/v1/auth/change-password')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ oldPassword: 'wrong', newPassword: 'newpass' });
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- allow authenticated users to change their password
- implement password update service and repository helpers
- document the new endpoint and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d70cd4f4832a8deb7032a99d09f3