### PR TITLE
feat: add email verification flow

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -492,13 +492,16 @@
           },
           "401": {
             "description": "Identifiants invalides"
+          },
+          "403": {
+            "description": "Email non vérifié"
           }
         }
       }
     },
     "/auth/register": {
       "post": {
-        "summary": "Créer un nouvel utilisateur",
+        "summary": "Créer un nouvel utilisateur (envoi d'un email de vérification)",
         "tags": [
           "Authentification"
         ],
@@ -703,6 +706,32 @@
           "400": {
             "description": "Token invalide ou requête invalide"
           }
+        }
+      }
+    },
+    "/auth/verify-email": {
+      "post": {
+        "summary": "Vérifier l'adresse email",
+        "tags": [
+          "Authentification"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["token"],
+                "properties": {
+                  "token": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": { "description": "Email vérifié" },
+          "400": { "description": "Token invalide ou manquant" }
         }
       }
     },

--- a/prisma/migrations/20250819201652_add-email-verification/migration.sql
+++ b/prisma/migrations/20250819201652_add-email-verification/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "email_verified" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "verification_token" TEXT;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,8 @@ model users {
   last_name     String?
   role          String  @default("user")
   created_at    DateTime @default(now())
+  email_verified Boolean @default(false)
+  verification_token String?
   password_reset_token String?
   password_reset_expires DateTime?
   announcements announcements[]

--- a/src/entities/user.entity.js
+++ b/src/entities/user.entity.js
@@ -9,6 +9,8 @@ class UserEntity {
     created_at,
     password_reset_token,
     password_reset_expires,
+    email_verified,
+    verification_token,
   }) {
     this.id = id;
     this.email = email;
@@ -19,6 +21,8 @@ class UserEntity {
     this.created_at = created_at;
     this.password_reset_token = password_reset_token;
     this.password_reset_expires = password_reset_expires;
+    this.email_verified = email_verified;
+    this.verification_token = verification_token;
   }
 }
 module.exports = UserEntity;

--- a/src/repositories/users.repository.js
+++ b/src/repositories/users.repository.js
@@ -7,9 +7,17 @@ exports.findByEmail = async (email) => {
   return row ? new UserEntity(row) : null;
 };
 
-exports.createUser = async ({ email, passwordHash, firstName, lastName, role }) => {
+exports.createUser = async ({ email, passwordHash, firstName, lastName, role, verificationToken }) => {
   const row = await prisma.users.create({
-    data: { email, password_hash: passwordHash, first_name: firstName, last_name: lastName, role },
+    data: {
+      email,
+      password_hash: passwordHash,
+      first_name: firstName,
+      last_name: lastName,
+      role,
+      verification_token: verificationToken,
+      email_verified: false,
+    },
   });
   return new UserEntity(row);
 };
@@ -79,6 +87,19 @@ exports.clearPasswordResetToken = async (id) => {
   const row = await prisma.users.update({
     where: { id },
     data: { password_reset_token: null, password_reset_expires: null },
+  });
+  return row ? new UserEntity(row) : null;
+};
+
+exports.findByVerificationToken = async (token) => {
+  const row = await prisma.users.findFirst({ where: { verification_token: token } });
+  return row ? new UserEntity(row) : null;
+};
+
+exports.markEmailVerified = async (id) => {
+  const row = await prisma.users.update({
+    where: { id },
+    data: { email_verified: true, verification_token: null },
   });
   return row ? new UserEntity(row) : null;
 };

--- a/src/routes/v1/auth.routes.js
+++ b/src/routes/v1/auth.routes.js
@@ -12,6 +12,7 @@ router.get('/me', userAuth, authController.me);
 router.post('/change-password', userAuth, authController.changePassword);
 router.post('/forgot-password', authController.forgotPassword);
 router.post('/reset-password', authController.resetPassword);
+router.post('/verify-email', authController.verifyEmail);
 
 router.post('/login-app', appsController.loginApp);
 router.post('/register-app', universalAuth, adminOnly({ verifyInDb: true }), appsController.registerApp);

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -47,3 +47,12 @@ exports.sendPasswordResetEmail = async (email, token) => {
     text: `Utilisez ce jeton pour réinitialiser votre mot de passe : ${token}`,
   });
 };
+
+exports.sendVerificationEmail = async (email, token) => {
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
+    to: email,
+    subject: 'Vérification de votre adresse email',
+    text: `Veuillez vérifier votre email avec ce jeton : ${token}`,
+  });
+};

--- a/tests/auth.email-verification.test.js
+++ b/tests/auth.email-verification.test.js
@@ -1,0 +1,70 @@
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../src/services/users.service');
+jest.mock('../src/services/email.service');
+jest.mock('../src/controllers/apps.controller', () => ({
+  loginApp: jest.fn(),
+  registerApp: jest.fn(),
+  registerAppApiKey: jest.fn(),
+}));
+jest.mock('../src/middlewares/auth-universal.middleware', () => jest.fn((req, res, next) => next()));
+const usersService = require('../src/services/users.service');
+const emailService = require('../src/services/email.service');
+const authRouter = require('../src/routes/v1/auth.routes');
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.use('/v1/auth', authRouter);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /v1/auth/register', () => {
+  test('creates user and sends verification email', async () => {
+    usersService.createUser.mockResolvedValue({
+      user: { id: 'u1', email: 'a@a.com' },
+      verificationToken: 'tok',
+    });
+    const res = await request(app)
+      .post('/v1/auth/register')
+      .send({ email: 'a@a.com', password: 'pass123' });
+    expect(res.status).toBe(201);
+    expect(usersService.createUser).toHaveBeenCalledWith({
+      email: 'a@a.com',
+      password: 'pass123',
+      firstName: undefined,
+      lastName: undefined,
+    });
+    expect(emailService.sendVerificationEmail).toHaveBeenCalledWith('a@a.com', 'tok');
+  });
+});
+
+describe('POST /v1/auth/verify-email', () => {
+  test('verifies email with valid token', async () => {
+    usersService.verifyEmail.mockResolvedValue(true);
+    const res = await request(app)
+      .post('/v1/auth/verify-email')
+      .send({ token: 'tok' });
+    expect(res.status).toBe(204);
+    expect(usersService.verifyEmail).toHaveBeenCalledWith('tok');
+  });
+
+  test('returns 400 when token invalid', async () => {
+    usersService.verifyEmail.mockResolvedValue(false);
+    const res = await request(app)
+      .post('/v1/auth/verify-email')
+      .send({ token: 'bad' });
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 400 when token missing', async () => {
+    const res = await request(app).post('/v1/auth/verify-email').send({});
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add email verification columns and migration
- generate and email verification token on signup
- implement endpoint to verify email and update docs

## Testing
- `npm test`
- `npm run lint` *(fails: StatEntity is assigned a value but never used and other no-unused-vars errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dafb1094832a8bad82030f5cfaff