### PR TITLE
feat: support HTML in bulk emails

### DIFF
--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -24,13 +24,13 @@ exports.get = async (req, res) => {
 
 exports.adminSend = async (req, res) => {
   try {
-    const { subject, body } = req.body || {};
+    const { subject, body, html } = req.body || {};
     const { stats, marketplace } = req.query || {};
     const emails = await emailService.getSubscribedEmails({
       stats: stats === 'true',
       marketplace: marketplace === 'true'
     });
-    const result = await emailService.sendBulkEmail(emails, subject, body);
+    const result = await emailService.sendBulkEmail(emails, subject, body, html);
     res.json(result);
   } catch (err) {
     console.error('Erreur envoi notifications admin:', err);

--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -20,7 +20,7 @@ const transporter = nodemailer.createTransport({
   },
 });
 
-exports.sendBulkEmail = async (addresses, subject, body) => {
+exports.sendBulkEmail = async (addresses, subject, text, html = text) => {
   const result = { sent: [], failed: [] };
   for (const addr of addresses) {
     try {
@@ -28,7 +28,8 @@ exports.sendBulkEmail = async (addresses, subject, body) => {
         from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
         to: addr,
         subject,
-        text: body,
+        text,
+        html,
       });
       result.sent.push(addr);
     } catch (err) {

--- a/tests/email.service.test.js
+++ b/tests/email.service.test.js
@@ -38,13 +38,14 @@ describe('email.service', () => {
 
     const emailService = require('../src/services/email.service');
 
-    await emailService.sendBulkEmail(['a@test.com'], 'subject', 'body');
+    await emailService.sendBulkEmail(['a@test.com'], 'subject', 'body', '<p>body</p>');
 
     expect(sendMail).toHaveBeenCalledWith({
       from: process.env.EMAIL_USER,
       to: 'a@test.com',
       subject: 'subject',
       text: 'body',
+      html: '<p>body</p>',
     });
   });
 
@@ -56,13 +57,14 @@ describe('email.service', () => {
 
     const emailService = require('../src/services/email.service');
 
-    await emailService.sendBulkEmail(['a@test.com'], 'subject', 'body');
+    await emailService.sendBulkEmail(['a@test.com'], 'subject', 'body', '<p>body</p>');
 
     expect(sendMail).toHaveBeenCalledWith({
       from: process.env.EMAIL_FROM,
       to: 'a@test.com',
       subject: 'subject',
       text: 'body',
+      html: '<p>body</p>',
     });
   });
 });


### PR DESCRIPTION
## Summary
- allow bulk emails to include HTML content
- forward HTML body from admin notification endpoint
- cover email service HTML behavior with tests

## Testing
- `npm test`
- `npm run lint` *(fails: EMAIL, err defined but unused, recaptcha not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e532ebc4832a8123437ec736c42c