### PR TITLE
feat(email): use HTML template for stats notifications

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -57,3 +57,24 @@ exports.sendVerificationEmail = async (email, token) => {
     text: `Veuillez vérifier votre email avec ce jeton : ${token}`,
   });
 };
+
+/**
+ * Build the subject, plain text and HTML body for the email sent when new
+ * statistics are available.
+ *
+ * @param {string} statsUrl URL to the statistics page
+ * @param {string[]} cultures List of culture names
+ * @param {number|string} year Year of the statistics
+ * @returns {{subject: string, text: string, html: string}}
+ */
+exports.buildStatsAvailableEmail = (statsUrl, cultures, year) => {
+  const cultureList = Array.isArray(cultures) ? cultures.join(', ') : cultures;
+  const subject = 'Nouvelles statistiques disponibles';
+  const text = `Les statistiques pour ${cultureList} ${year} sont disponibles : ${statsUrl}`;
+  const html = `
+    <h1>Statistiques disponibles</h1>
+    <p>Les statistiques pour ${cultureList} ${year} sont maintenant disponibles.</p>
+    <p><a href="${statsUrl}">${statsUrl}</a></p>
+  `;
+  return { subject, text, html };
+};

--- a/tests/email.service.test.js
+++ b/tests/email.service.test.js
@@ -67,5 +67,22 @@ describe('email.service', () => {
       html: '<p>body</p>',
     });
   });
+
+  test('buildStatsAvailableEmail returns subject, text and html', () => {
+    const emailService = require('../src/services/email.service');
+    const { subject, text, html } = emailService.buildStatsAvailableEmail(
+      'http://example.com/stats',
+      ['blé', 'maïs'],
+      2023,
+    );
+
+    expect(subject).toBe('Nouvelles statistiques disponibles');
+    expect(text).toBe(
+      'Les statistiques pour blé, maïs 2023 sont disponibles : http://example.com/stats'
+    );
+    expect(html).toContain('<h1>Statistiques disponibles</h1>');
+    expect(html).toContain('blé, maïs 2023');
+    expect(html).toContain('<a href="http://example.com/stats"');
+  });
 });
 


### PR DESCRIPTION
## Summary
- add `buildStatsAvailableEmail` to generate subject, text and HTML body for statistics notifications
- test new HTML output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e72c2c24832aaa8388d530aea4b2