### PR TITLE
docs: clarify HTML body for notifications

### DIFF
--- a/docs/v1/swagger.json
+++ b/docs/v1/swagger.json
@@ -1131,13 +1131,18 @@
                     "type": "string"
                   },
                   "body": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "HTML content of the notification. For marketplace notifications include <a href=\"{{link}}\">{{name}}</a>."
                   }
                 },
                 "required": [
                   "subject",
                   "body"
                 ]
+              },
+              "example": {
+                "subject": "Nouvelle annonce",
+                "body": "<p>Nouvelle annonce sur le marketplace : <a href=\"{{link}}\">{{name}}</a></p>"
               }
             }
           }

--- a/docs/v2/swagger.json
+++ b/docs/v2/swagger.json
@@ -96,9 +96,16 @@
                 "type": "object",
                 "properties": {
                   "subject": { "type": "string" },
-                  "body": { "type": "string" }
+                  "body": {
+                    "type": "string",
+                    "description": "HTML content of the notification. For marketplace notifications include <a href=\"{{link}}\">{{name}}</a>."
+                  }
                 },
                 "required": ["subject", "body"]
+              },
+              "example": {
+                "subject": "Nouvelle annonce",
+                "body": "<p>Nouvelle annonce sur le marketplace : <a href=\"{{link}}\">{{name}}</a></p>"
               }
             }
           }


### PR DESCRIPTION
## Summary
- specify HTML content for notification `body` field
- add HTML example with `{{name}}` and `{{link}}` placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e94f2ad4832ab70f0206d386a3f5