### PR TITLE
refactor: use path.join for email templates

### DIFF
--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const { sendMail } = require('../utils/mailer');
+
+const templates = {
+  stats: {
+    subject: 'Farm statistics',
+    path: path.join(__dirname, '../templates/emails/statsTemplate.html'),
+  },
+  alert: {
+    subject: 'Alert',
+    path: path.join(__dirname, '../templates/emails/alertTemplate.html'),
+  },
+  welcome: {
+    subject: 'Welcome',
+    path: path.join(__dirname, '../templates/emails/welcomeTemplate.html'),
+  },
+};
+
+async function sendNotification(type, to, data) {
+  const template = templates[type];
+  if (!template) {
+    throw new Error(`Unknown notification type: ${type}`);
+  }
+  await sendMail(to, template.subject, template.path, data);
+}
+
+module.exports = { sendNotification };


### PR DESCRIPTION
## Summary
- add notifications service that loads email templates using path.join

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "require('./src/services/notifications.service'); console.log('loaded')"` *(fails: Cannot find module 'handlebars')*

------
https://chatgpt.com/codex/tasks/task_e_68a786f30900832a99b974758855b3f7