### PR TITLE
Add audience or emails check in notifications controller

### DIFF
--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -1,0 +1,29 @@
+const { sendNotification } = require('../services/notifications.service');
+
+async function notify(req, res) {
+  const { type, subject, audience, emails = [], data } = req.body || {};
+
+  if (!type) {
+    return res.status(400).json({ error: 'type is required' });
+  }
+
+  if (!subject) {
+    return res.status(400).json({ error: 'subject is required' });
+  }
+
+  if (!audience && (!Array.isArray(emails) || emails.length === 0)) {
+    return res
+      .status(400)
+      .json({ error: 'Either audience or a non-empty emails array must be provided' });
+  }
+
+  try {
+    const recipients = audience || emails;
+    await sendNotification(type, recipients, data);
+    return res.status(200).json({ message: 'Notification sent' });
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+}
+
+module.exports = { notify };


### PR DESCRIPTION
## Summary
- add notifications controller to validate required fields and send notifications
- require either `audience` or a non-empty `emails` list before sending

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a787cacd08832a8aa4fdb9a3c9c8d8