### PR TITLE
Validate email recipients in notifications service

### DIFF
--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -16,12 +16,29 @@ const templates = {
   },
 };
 
+function resolveRecipients(to) {
+  const recipients = Array.isArray(to) ? to : [to];
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const unique = new Set();
+
+  for (const email of recipients) {
+    const trimmed = typeof email === 'string' ? email.trim() : '';
+    if (!emailRegex.test(trimmed)) {
+      throw new Error(`Invalid email address: ${email}`);
+    }
+    unique.add(trimmed);
+  }
+
+  return Array.from(unique);
+}
+
 async function sendNotification(type, to, data) {
   const template = templates[type];
   if (!template) {
     throw new Error(`Unknown notification type: ${type}`);
   }
-  await sendMail(to, template.subject, template.path, data);
+  const recipients = resolveRecipients(to);
+  await sendMail(recipients, template.subject, template.path, data);
 }
 
 module.exports = { sendNotification };


### PR DESCRIPTION
## Summary
- add `resolveRecipients` helper to validate email format and deduplicate recipients
- integrate recipient resolution into notification sending

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a788b85d44832ab8ef12a518b79a1f