### PR TITLE
Send templated emails concurrently and track results

### DIFF
--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -19,8 +19,8 @@ async function notify(req, res) {
 
   try {
     const recipients = audience || emails;
-    await sendNotification(type, recipients, data);
-    return res.status(200).json({ message: 'Notification sent' });
+    const { sent, skipped } = await sendNotification(type, recipients, data);
+    return res.status(200).json({ message: 'Notification sent', sent, skipped });
   } catch (error) {
     return res.status(500).json({ error: error.message });
   }

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { sendMail } = require('../utils/mailer');
+const { sendTemplatedEmail } = require('../utils/mailer');
 
 const templates = {
   stats: {
@@ -38,7 +38,7 @@ async function sendNotification(type, to, data) {
     throw new Error(`Unknown notification type: ${type}`);
   }
   const recipients = resolveRecipients(to);
-  await sendMail(recipients, template.subject, template.path, data);
+  return sendTemplatedEmail(recipients, template.subject, template.path, data);
 }
 
 module.exports = { sendNotification };

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -35,4 +35,66 @@ async function sendMail(to, subject, templatePath, data = {}) {
   });
 }
 
-module.exports = { sendMail };
+/**
+ * Send a templated email to multiple recipients with limited concurrency.
+ *
+ * @param {string[]} recipients - List of email addresses to send to.
+ * @param {string} subject - Email subject.
+ * @param {string} templatePath - Path to the handlebars template.
+ * @param {Object} [data={}] - Data for the template.
+ * @param {number} [batchSize=5] - Number of concurrent emails to send.
+ * @returns {Promise<{sent: number, skipped: number}>}
+ */
+async function sendTemplatedEmail(
+  recipients,
+  subject,
+  templatePath,
+  data = {},
+  batchSize = 5
+) {
+  const template = await loadTemplate(templatePath);
+  const html = template(data);
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: process.env.SMTP_USER
+      ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+      : undefined,
+  });
+
+  let sent = 0;
+  let skipped = 0;
+
+  for (let i = 0; i < recipients.length; i += batchSize) {
+    const batch = recipients.slice(i, i + batchSize);
+    const results = await Promise.all(
+      batch.map(async (to) => {
+        try {
+          await transporter.sendMail({
+            from: process.env.SMTP_FROM,
+            to,
+            subject,
+            html,
+          });
+          return true;
+        } catch (err) {
+          return false;
+        }
+      })
+    );
+
+    for (const result of results) {
+      if (result) {
+        sent += 1;
+      } else {
+        skipped += 1;
+      }
+    }
+  }
+
+  return { sent, skipped };
+}
+
+module.exports = { sendMail, sendTemplatedEmail };


### PR DESCRIPTION
## Summary
- Send templated emails in concurrent batches with success/failure tracking
- Propagate sent and skipped counts through notification service and controller

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a789a65c1c832a8019bb3680201fba