### PR TITLE
feat: add templated notification sender

### DIFF
--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -22,6 +22,35 @@ exports.get = async (req, res) => {
   }
 };
 
+exports.send = async (req, res) => {
+  try {
+    const { type, subject, product, year, link } = req.body || {};
+    if (!type || !subject) return res.status(400).json({ error: 'Type et sujet requis' });
+
+    if (type === 'stats') {
+      if (!product || !year || !link) {
+        return res.status(400).json({ error: 'Produit, année et lien requis' });
+      }
+    } else if (type === 'marketplace') {
+      if (!link) return res.status(400).json({ error: 'Lien requis' });
+    } else {
+      return res.status(400).json({ error: 'Type invalide' });
+    }
+
+    const { sent, skipped } = await notificationsService.sendTemplatedEmail({
+      type,
+      subject,
+      product,
+      year,
+      link,
+    });
+    res.json({ sent, skipped });
+  } catch (err) {
+    console.error('Erreur envoi notification:', err);
+    res.status(500).json({ error: "Erreur lors de l'envoi de la notification" });
+  }
+};
+
 exports.adminSend = async (req, res) => {
   try {
     const { subject, body, html } = req.body || {};


### PR DESCRIPTION
## Summary
- add send endpoint to notifications controller
- validate parameters for stats and marketplace notifications
- invoke notificationsService.sendTemplatedEmail and return results

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet)*
- `npm run lint` *(fails: no-unused-vars, no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_68a78f88debc832a90961e09825ddf99