### PR TITLE
feat: add templated email notifications

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -78,3 +78,13 @@ exports.buildStatsAvailableEmail = (statsUrl, cultures, year) => {
   `;
   return { subject, text, html };
 };
+
+exports.sendHtmlNotification = async ({ to, type, subject, variables = {} }) => {
+  const html = variables.html || '';
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || process.env.EMAIL_USER,
+    to,
+    subject,
+    html,
+  });
+};

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -1,5 +1,7 @@
 const notificationsRepository = require('../repositories/notifications.repository');
 const { entityToModel } = require('../mapping/notification.mapping');
+const usersRepository = require('../repositories/users.repository');
+const emailService = require('./email.service');
 
 exports.subscribe = async (userId, { stats = false, marketplace = false }) => {
   const entity = await notificationsRepository.upsert({ userId, stats, marketplace });
@@ -10,3 +12,47 @@ exports.getPreferences = async (userId) => {
   const entity = await notificationsRepository.findByUserId(userId);
   return entityToModel(entity);
 };
+
+exports.sendTemplatedEmail = async ({
+  type,
+  subject,
+  variables = {},
+  audience,
+  emails = [],
+}) => {
+  const recipients = await resolveRecipients({ audience, emails });
+  let sent = 0;
+  let skipped = 0;
+
+  for (const addr of recipients) {
+    try {
+      await emailService.sendHtmlNotification({
+        to: addr,
+        type,
+        subject,
+        variables,
+      });
+      sent += 1;
+    } catch (err) {
+      console.error('Erreur envoi notification vers', addr, err);
+      skipped += 1;
+    }
+  }
+
+  return { sent, skipped };
+};
+
+async function resolveRecipients({ audience, emails }) {
+  if (Array.isArray(emails) && emails.length) return emails;
+
+  const search = {
+    stats: audience === 'stats',
+    marketplace: audience === 'marketplace',
+  };
+
+  const userIds = await notificationsRepository.findSubscribed(search);
+  if (!userIds.length) return [];
+
+  const users = await usersRepository.listByIds(userIds);
+  return users.map((u) => u.email);
+}


### PR DESCRIPTION
## Summary
- add templated email sender in notifications service
- allow HTML notification sending via email service

## Testing
- `npm test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68a791ca7394832a9576a75c500b1d61