### PR TITLE
feat: add HTML mail utility

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -20,6 +20,8 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+exports.transporter = transporter;
+
 exports.sendBulkEmail = async (addresses, subject, text, html = text) => {
   const result = { sent: [], failed: [] };
   for (const addr of addresses) {

--- a/src/utils/mailer.js
+++ b/src/utils/mailer.js
@@ -1,1 +1,27 @@
-x
+const fs = require('fs');
+const handlebars = require('handlebars');
+const { transporter } = require('../services/email.service');
+
+/**
+ * Sends an HTML email based on a Handlebars template.
+ *
+ * @param {Object} options
+ * @param {string} options.to Recipient email address
+ * @param {string} options.subject Email subject
+ * @param {string} options.templatePath Path to the Handlebars template file
+ * @param {Object} [options.variables={}] Variables to interpolate in the template
+ */
+async function sendHtmlNotification({ to, subject, templatePath, variables = {} }) {
+  const templateSource = fs.readFileSync(templatePath, 'utf8');
+  const template = handlebars.compile(templateSource);
+  const html = template(variables);
+
+  await transporter.sendMail({
+    from: process.env.EMAIL_SENDER,
+    to,
+    subject,
+    html,
+  });
+}
+
+module.exports = { sendHtmlNotification };


### PR DESCRIPTION
## Summary
- add reusable sendHtmlNotification utility to render templates with Handlebars and send via Nodemailer
- expose email transporter for cross-module reuse

## Testing
- `npm test`
- `npm run lint` *(fails: EMAIL, err, recaptcha, etc. undefined/no-unused-vars)*


------
https://chatgpt.com/codex/tasks/task_e_68ab6afe3e08832aa23c109eb107b0b2