### PR TITLE
feat: add templated email support

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -1,3 +1,4 @@
+const fs = require('fs/promises');
 const { sendMail } = require('../utils/mailer');
 
 exports.sendPasswordResetEmail = async (email, token) => {
@@ -14,4 +15,10 @@ exports.sendVerificationEmail = async (email, token) => {
     subject: 'Vérification de votre adresse email',
     text: `Veuillez vérifier votre email avec ce jeton : ${token}`,
   });
+};
+
+exports.sendHtmlNotification = async ({ to, subject, templatePath, variables }) => {
+  const template = await fs.readFile(templatePath, 'utf8');
+  const html = template.replace(/{{\s*(\w+)\s*}}/g, (_, key) => variables[key] ?? '');
+  await sendMail({ to, subject, html });
 };

--- a/src/templates/emails/marketplaceTemplate.html
+++ b/src/templates/emails/marketplaceTemplate.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <h1>Nouvelle annonce</h1>
+    <p>{{name}}</p>
+    <p><a href="{{link}}">Voir l'annonce</a></p>
+  </body>
+</html>

--- a/src/templates/emails/statsTemplate.html
+++ b/src/templates/emails/statsTemplate.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <h1>Statistiques</h1>
+    <p>Produit: {{product}}</p>
+    <p>Année: {{year}}</p>
+    <p><a href="{{link}}">Voir les statistiques</a></p>
+  </body>
+</html>

--- a/tests/email.templates.test.js
+++ b/tests/email.templates.test.js
@@ -1,0 +1,49 @@
+const path = require('path');
+
+jest.mock('../src/utils/mailer', () => ({
+  sendMail: jest.fn(),
+}));
+
+const mailer = require('../src/utils/mailer');
+const emailService = require('../src/services/email.service');
+
+describe('emailService.sendHtmlNotification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('compiles stats template with variables', async () => {
+    await emailService.sendHtmlNotification({
+      to: 'user@test.com',
+      subject: 'Stats',
+      templatePath: path.join(process.cwd(), 'src/templates/emails/statsTemplate.html'),
+      variables: { product: 'Wheat', year: 2024, link: 'http://stats' },
+    });
+
+    expect(mailer.sendMail).toHaveBeenCalledWith({
+      to: 'user@test.com',
+      subject: 'Stats',
+      html: expect.stringContaining('Wheat'),
+    });
+    const html = mailer.sendMail.mock.calls[0][0].html;
+    expect(html).toContain('2024');
+    expect(html).toContain('http://stats');
+  });
+
+  test('compiles marketplace template with variables', async () => {
+    await emailService.sendHtmlNotification({
+      to: 'user@test.com',
+      subject: 'Market',
+      templatePath: path.join(process.cwd(), 'src/templates/emails/marketplaceTemplate.html'),
+      variables: { name: 'Tractor', link: 'http://market' },
+    });
+
+    expect(mailer.sendMail).toHaveBeenCalledWith({
+      to: 'user@test.com',
+      subject: 'Market',
+      html: expect.stringContaining('Tractor'),
+    });
+    const html = mailer.sendMail.mock.calls[0][0].html;
+    expect(html).toContain('http://market');
+  });
+});

--- a/tests/notifications.send.test.js
+++ b/tests/notifications.send.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const express = require('express');
+const path = require('path');
 
 describe('notificationsService.sendTemplatedEmail', () => {
   let notificationsService;
@@ -24,8 +25,11 @@ describe('notificationsService.sendTemplatedEmail', () => {
     });
     expect(emailService.sendHtmlNotification).toHaveBeenCalledWith({
       to: 'user@test.com',
-      type: 'stats',
       subject: 'Stats Update',
+      templatePath: path.join(
+        process.cwd(),
+        'src/templates/emails/statsTemplate.html',
+      ),
       variables: { product: 'Wheat', year: 2024, link: 'http://stats' },
     });
     expect(result).toEqual({ sent: 1, skipped: 0 });
@@ -41,8 +45,11 @@ describe('notificationsService.sendTemplatedEmail', () => {
     });
     expect(emailService.sendHtmlNotification).toHaveBeenCalledWith({
       to: 'user@test.com',
-      type: 'marketplace',
       subject: 'New Item',
+      templatePath: path.join(
+        process.cwd(),
+        'src/templates/emails/marketplaceTemplate.html',
+      ),
       variables: { name: 'Tractor', link: 'http://market' },
     });
     expect(result).toEqual({ sent: 1, skipped: 0 });


### PR DESCRIPTION
## Summary
- resolve templates by type in notifications service and send via email service
- implement HTML template compilation in email service
- add stats and marketplace email templates with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab764eeb4c832aa4e3dd7beb2b1ae7