### PR TITLE
feat: add email verification email template

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -1,4 +1,5 @@
 const fs = require('fs/promises');
+const path = require('path');
 const { sendMail } = require('../utils/mailer');
 
 exports.sendPasswordResetEmail = async (email, token) => {
@@ -10,10 +11,12 @@ exports.sendPasswordResetEmail = async (email, token) => {
 };
 
 exports.sendVerificationEmail = async (email, token) => {
-  await sendMail({
+  const link = `https://example.com/verify-email?token=${token}`;
+  await exports.sendHtmlNotification({
     to: email,
     subject: 'Vérification de votre adresse email',
-    text: `Veuillez vérifier votre email avec ce jeton : ${token}`,
+    templatePath: path.join(__dirname, '../templates/emails/emailVerificationTemplate.html'),
+    variables: { name: email, link },
   });
 };
 

--- a/src/templates/emails/emailVerificationTemplate.html
+++ b/src/templates/emails/emailVerificationTemplate.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Vérification de l'adresse email</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #333;">
+  <h2>🔐 Vérifiez votre adresse email</h2>
+  <p>Bonjour {{name}},</p>
+  <p>Merci de vous être inscrit sur Cultiviso. Pour terminer votre inscription, veuillez confirmer votre adresse email.</p>
+  <p>
+    👉 <a href="{{link}}" target="_blank" style="color: green;">Confirmer mon adresse email</a>
+  </p>
+  <hr/>
+  <small>Si vous n'êtes pas à l'origine de cette inscription, ignorez simplement cet email.</small>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML template for verification emails with `name` and `link`
- send verification emails via `sendHtmlNotification`

## Testing
- `npm test`
- `npm run lint` *(fails: 'StatEntity' is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abaa808638832aabdd61b53867661c