### PR TITLE
feat(email): add password reset template

### DIFF
--- a/src/services/email.service.js
+++ b/src/services/email.service.js
@@ -3,10 +3,12 @@ const path = require('path');
 const { sendMail } = require('../utils/mailer');
 
 exports.sendPasswordResetEmail = async (email, token) => {
-  await sendMail({
+  const link = `https://example.com/reset-password?token=${token}`;
+  await exports.sendHtmlNotification({
     to: email,
     subject: 'Réinitialisation de mot de passe',
-    text: `Utilisez ce jeton pour réinitialiser votre mot de passe : ${token}`,
+    templatePath: path.join(__dirname, '../templates/emails/passwordResetTemplate.html'),
+    variables: { name: email, link },
   });
 };
 

--- a/src/templates/emails/passwordResetTemplate.html
+++ b/src/templates/emails/passwordResetTemplate.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Réinitialisation de mot de passe</title>
+</head>
+<body style="font-family: Arial, sans-serif; color: #333;">
+  <h2>🔒 Réinitialisation de mot de passe</h2>
+  <p>Bonjour {{name}},</p>
+  <p>Vous avez demandé la réinitialisation de votre mot de passe.</p>
+  <p>Veuillez cliquer sur le lien ci-dessous pour définir un nouveau mot de passe :</p>
+  <p>
+    👉 <a href="{{link}}" target="_blank" style="color: green;">Réinitialiser mon mot de passe</a>
+  </p>
+  <hr/>
+  <small>Si vous n'avez pas demandé cette réinitialisation, vous pouvez ignorer cet email.</small>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add password reset HTML template
- send password reset emails using HTML notification helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abab72e318832abad98b2eb0cc2597