### PR TITLE
test: cover email templates and path assertions

### DIFF
--- a/tests/auth.email-verification.test.js
+++ b/tests/auth.email-verification.test.js
@@ -1,8 +1,8 @@
 const request = require('supertest');
 const express = require('express');
+const path = require('path');
 
 jest.mock('../src/services/users.service');
-jest.mock('../src/services/email.service');
 jest.mock('../src/controllers/apps.controller', () => ({
   loginApp: jest.fn(),
   registerApp: jest.fn(),
@@ -11,6 +11,7 @@ jest.mock('../src/controllers/apps.controller', () => ({
 jest.mock('../src/middlewares/auth-universal.middleware', () => jest.fn((req, res, next) => next()));
 const usersService = require('../src/services/users.service');
 const emailService = require('../src/services/email.service');
+jest.spyOn(emailService, 'sendHtmlNotification').mockResolvedValue();
 const authRouter = require('../src/routes/v1/auth.routes');
 
 let app;
@@ -41,7 +42,13 @@ describe('POST /v1/auth/register', () => {
       firstName: undefined,
       lastName: undefined,
     });
-    expect(emailService.sendVerificationEmail).toHaveBeenCalledWith('a@a.com', 'tok');
+    const templatePath = path.join(
+      process.cwd(),
+      'src/templates/emails/emailVerificationTemplate.html',
+    );
+    expect(emailService.sendHtmlNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ templatePath }),
+    );
   });
 });
 

--- a/tests/email.templates.test.js
+++ b/tests/email.templates.test.js
@@ -46,4 +46,38 @@ describe('emailService.sendHtmlNotification', () => {
     const html = mailer.sendMail.mock.calls[0][0].html;
     expect(html).toContain('http://market');
   });
+
+  test('compiles email verification template with variables', async () => {
+    await emailService.sendHtmlNotification({
+      to: 'user@test.com',
+      subject: 'Verify',
+      templatePath: path.join(process.cwd(), 'src/templates/emails/emailVerificationTemplate.html'),
+      variables: { name: 'Alice', link: 'http://verify' },
+    });
+
+    expect(mailer.sendMail).toHaveBeenCalledWith({
+      to: 'user@test.com',
+      subject: 'Verify',
+      html: expect.stringContaining('Alice'),
+    });
+    const html = mailer.sendMail.mock.calls[0][0].html;
+    expect(html).toContain('http://verify');
+  });
+
+  test('compiles password reset template with variables', async () => {
+    await emailService.sendHtmlNotification({
+      to: 'user@test.com',
+      subject: 'Reset',
+      templatePath: path.join(process.cwd(), 'src/templates/emails/passwordResetTemplate.html'),
+      variables: { name: 'Bob', link: 'http://reset' },
+    });
+
+    expect(mailer.sendMail).toHaveBeenCalledWith({
+      to: 'user@test.com',
+      subject: 'Reset',
+      html: expect.stringContaining('Bob'),
+    });
+    const html = mailer.sendMail.mock.calls[0][0].html;
+    expect(html).toContain('http://reset');
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for email verification and password reset templates
- assert sendHtmlNotification uses correct template paths in auth routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac3c7b7554832a85dd2c6eaa729331